### PR TITLE
[Compiler] Chapter3: Add OpPop

### DIFF
--- a/code/code.go
+++ b/code/code.go
@@ -52,6 +52,7 @@ type Opcode byte
 const (
 	OpConstant Opcode = iota
 	OpAdd
+	OpPop
 )
 
 type Definition struct {
@@ -62,6 +63,7 @@ type Definition struct {
 var definitions = map[Opcode]*Definition{
 	OpConstant: {"OpConstant", []int{2}}, // Thus, up to 65536 constants could be defied.
 	OpAdd:      {"OpAdd", []int{}},
+	OpPop:      {"OpPop", []int{}},
 }
 
 func Lookup(op byte) (*Definition, error) {

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -33,6 +33,7 @@ func (c *Compiler) Compile(node ast.Node) error {
 		if err != nil {
 			return err
 		}
+		c.emit(code.OpPop)
 	case *ast.InfixExpression:
 		err := c.Compile(node.Left)
 		if err != nil {

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -24,6 +24,17 @@ func TestIntegerArithmetic(t *testing.T) {
 				code.Make(code.OpConstant, 0),
 				code.Make(code.OpConstant, 1),
 				code.Make(code.OpAdd),
+				code.Make(code.OpPop),
+			},
+			expectedConstants: []interface{}{1, 2},
+		},
+		{
+			input: "1; 2;",
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpPop),
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpPop),
 			},
 			expectedConstants: []interface{}{1, 2},
 		},

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -58,8 +58,8 @@ func Start(in io.Reader, out io.Writer) {
 			continue
 		}
 
-		stackTop := machine.StackTop()
-		io.WriteString(out, stackTop.Inspect())
+		stackElem := machine.LastPoppedStackElem()
+		io.WriteString(out, stackElem.Inspect())
 		io.WriteString(out, "\n")
 	}
 }

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -24,6 +24,11 @@ func (vm *VM) StackTop() object.Object {
 	return vm.stack[vm.sp-1]
 }
 
+// invalid if the last operation was, say, pushing.
+func (vm *VM) LastPoppedStackElem() object.Object {
+	return vm.stack[vm.sp]
+}
+
 func (vm *VM) Run() error {
 	for ip := 0; ip < len(vm.instructions); ip++ {
 		op := code.Opcode(vm.instructions[ip])

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -51,6 +51,8 @@ func (vm *VM) Run() error {
 			if err != nil {
 				return err
 			}
+		case code.OpPop:
+			vm.pop()
 		}
 	}
 	return nil

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -44,7 +44,7 @@ func runVmTests(t *testing.T, tests []vmTestCase) {
 		if err != nil {
 			t.Fatalf("vm error: %s", err)
 		}
-		stackElem := vm.StackTop()
+		stackElem := vm.LastPoppedStackElem()
 		testExpectedObject(t, tt.expected, stackElem)
 	}
 }


### PR DESCRIPTION
- Add Opcode `OpPop` in order that
   - the compiler emits an `oppop` instruction.
   - the vm understands an `oppop` instruction.

Using this new opcode, I modified below.

- Emit `OpPop` in the end when compiling ast.ExpressionStatement.