### PR TITLE
Enable our compiler + VM to compile and execute conditional expressions

### DIFF
--- a/code/code.go
+++ b/code/code.go
@@ -26,6 +26,7 @@ const (
 	OpPop
 	OpJumpNotTruthy
 	OpJump
+	OpNull
 )
 
 type Definition struct {
@@ -49,6 +50,7 @@ var definitions = map[Opcode]*Definition{
 	OpPop:           {"OpPop", []int{}},
 	OpJumpNotTruthy: {"OpJumpNotTruthy", []int{2}},
 	OpJump:          {"OpJump", []int{2}},
+	OpNull:          {"OpNull", []int{}},
 }
 
 func Lookup(op byte) (*Definition, error) {

--- a/code/code.go
+++ b/code/code.go
@@ -24,6 +24,8 @@ const (
 	OpMinus
 	OpBang
 	OpPop
+	OpJumpNotTruthy
+	OpJump
 )
 
 type Definition struct {
@@ -32,19 +34,21 @@ type Definition struct {
 }
 
 var definitions = map[Opcode]*Definition{
-	OpConstant:    {"OpConstant", []int{2}}, // Thus, up to 65536 constants could be defied.
-	OpTrue:        {"OpTrue", []int{}},
-	OpFalse:       {"OpFalse", []int{}},
-	OpAdd:         {"OpAdd", []int{}},
-	OpSub:         {"OpSub", []int{}},
-	OpMul:         {"OpMul", []int{}},
-	OpDiv:         {"OpDiv", []int{}},
-	OpEqual:       {"OpEqual", []int{}},
-	OpNotEqual:    {"OpNotEqual", []int{}},
-	OpGreaterThan: {"OpGreaterThan", []int{}},
-	OpMinus:       {"OpMinus", []int{}},
-	OpBang:        {"OpBang", []int{}},
-	OpPop:         {"OpPop", []int{}},
+	OpConstant:      {"OpConstant", []int{2}}, // Thus, up to 65536 constants could be defied.
+	OpTrue:          {"OpTrue", []int{}},
+	OpFalse:         {"OpFalse", []int{}},
+	OpAdd:           {"OpAdd", []int{}},
+	OpSub:           {"OpSub", []int{}},
+	OpMul:           {"OpMul", []int{}},
+	OpDiv:           {"OpDiv", []int{}},
+	OpEqual:         {"OpEqual", []int{}},
+	OpNotEqual:      {"OpNotEqual", []int{}},
+	OpGreaterThan:   {"OpGreaterThan", []int{}},
+	OpMinus:         {"OpMinus", []int{}},
+	OpBang:          {"OpBang", []int{}},
+	OpPop:           {"OpPop", []int{}},
+	OpJumpNotTruthy: {"OpJumpNotTruthy", []int{2}},
+	OpJump:          {"OpJump", []int{2}},
 }
 
 func Lookup(op byte) (*Definition, error) {

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -8,14 +8,23 @@ import (
 )
 
 type Compiler struct {
-	instructions code.Instructions
-	constants    []object.Object
+	instructions        code.Instructions
+	constants           []object.Object
+	lastInstruction     EmittedInstruction
+	previousInstruction EmittedInstruction
+}
+
+type EmittedInstruction struct {
+	Opcode   code.Opcode
+	Position int
 }
 
 func New() *Compiler {
 	return &Compiler{
-		instructions: code.Instructions{},
-		constants:    []object.Object{},
+		instructions:        code.Instructions{},
+		constants:           []object.Object{},
+		lastInstruction:     EmittedInstruction{},
+		previousInstruction: EmittedInstruction{},
 	}
 }
 
@@ -110,6 +119,8 @@ Returns an index of the newly added opcode.
 func (c *Compiler) emit(op code.Opcode, operands ...int) int {
 	ins := code.Make(op, operands...)
 	pos := c.addInstruction(ins)
+
+	c.setLastInstruction(op, pos)
 	return pos
 }
 
@@ -121,6 +132,14 @@ func (c *Compiler) addInstruction(ins []byte) int {
 	posNewInstruction := len(c.instructions)
 	c.instructions = append(c.instructions, ins...)
 	return posNewInstruction
+}
+
+func (c *Compiler) setLastInstruction(op code.Opcode, pos int) {
+	previous := c.lastInstruction
+	last := EmittedInstruction{Opcode: op, Position: pos}
+
+	c.previousInstruction = previous
+	c.lastInstruction = last
 }
 
 type Bytecode struct {

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -122,8 +122,28 @@ func (c *Compiler) Compile(node ast.Node) error {
 			c.removeLastPop()
 		}
 
-		afterConsequencePos := len(c.instructions)
-		c.changeOperand(jumpNotTruthyPos, afterConsequencePos)
+		if node.Alternative == nil {
+			afterConsequencePos := len(c.instructions)
+			c.changeOperand(jumpNotTruthyPos, afterConsequencePos)
+		} else {
+			// Use backpatching here.
+			jumpPos := c.emit(code.OpJump, 9999)
+			// Does not reach here when condition is evaluated to be true.
+			afterConsequencePos := len(c.instructions)
+			c.changeOperand(jumpNotTruthyPos, afterConsequencePos)
+
+			err := c.Compile(node.Alternative)
+			if err != nil {
+				return err
+			}
+
+			if c.lastInstructionIsPop() {
+				c.removeLastPop()
+			}
+
+			afterAlternativePos := len(c.instructions)
+			c.changeOperand(jumpPos, afterAlternativePos)
+		}
 	case *ast.BlockStatement:
 		for _, s := range node.Statements {
 			err := c.Compile(s)

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -172,7 +172,7 @@ func TestBooleanExpressions(t *testing.T) {
 	runCompilerTest(t, tests)
 }
 
-func TestConditionals(t *testing.T){
+func TestConditionals(t *testing.T) {
 	tests := []compilerTestCase{
 		{
 			input: `
@@ -183,14 +183,18 @@ func TestConditionals(t *testing.T){
 				// 0000
 				code.Make(code.OpTrue),
 				// 0001
-				code.Make(code.OpJumpNotTruthy, 7),
+				code.Make(code.OpJumpNotTruthy, 10),
 				// 0004
 				code.Make(code.OpConstant, 0),
 				// 0007
-				code.Make(code.OpPop),
-				// 0008
-				code.Make(code.OpConstant, 1),
+				code.Make(code.OpJump, 11),
+				// 0010
+				code.Make(code.OpNull),
 				// 0011
+				code.Make(code.OpPop),
+				// 0012
+				code.Make(code.OpConstant, 1),
+				// 0015
 				code.Make(code.OpPop),
 			},
 		},
@@ -216,7 +220,30 @@ func TestConditionals(t *testing.T){
 				code.Make(code.OpConstant, 2),
 				// 0017
 				code.Make(code.OpPop),
-
+			},
+		},
+		{
+			input: `
+			if (true) { 10 }; 3333
+			`,
+			expectedConstants: []interface{}{10, 3333},
+			expectedInstructions: []code.Instructions{
+				// 0000
+				code.Make(code.OpTrue),
+				// 0001
+				code.Make(code.OpJumpNotTruthy, 10),
+				// 0004
+				code.Make(code.OpConstant, 0),
+				// 0007
+				code.Make(code.OpJump, 11),
+				// 0010
+				code.Make(code.OpNull),
+				// 0011
+				code.Make(code.OpPop),
+				// 0012
+				code.Make(code.OpConstant, 1),
+				// 0015
+				code.Make(code.OpPop),
 			},
 		},
 	}

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -194,6 +194,31 @@ func TestConditionals(t *testing.T){
 				code.Make(code.OpPop),
 			},
 		},
+		{
+			input: `
+			if (true){ 10 } else { 20 }; 3333;
+			`,
+			expectedConstants: []interface{}{10, 20, 3333},
+			expectedInstructions: []code.Instructions{
+				// 0000
+				code.Make(code.OpTrue),
+				// 0001
+				code.Make(code.OpJumpNotTruthy, 10),
+				// 0004
+				code.Make(code.OpConstant, 0),
+				// 0007
+				code.Make(code.OpJump, 13),
+				// 0010
+				code.Make(code.OpConstant, 1),
+				// 0013
+				code.Make(code.OpPop),
+				// 0014
+				code.Make(code.OpConstant, 2),
+				// 0017
+				code.Make(code.OpPop),
+
+			},
+		},
 	}
 	runCompilerTest(t, tests)
 }

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -172,6 +172,32 @@ func TestBooleanExpressions(t *testing.T) {
 	runCompilerTest(t, tests)
 }
 
+func TestConditionals(t *testing.T){
+	tests := []compilerTestCase{
+		{
+			input: `
+			if (true) { 10 }; 3333;
+			`,
+			expectedConstants: []interface{}{10, 3333},
+			expectedInstructions: []code.Instructions{
+				// 0000
+				code.Make(code.OpTrue),
+				// 0001
+				code.Make(code.OpJumpNotTruthy, 7),
+				// 0004
+				code.Make(code.OpConstant, 0),
+				// 0007
+				code.Make(code.OpPop),
+				// 0008
+				code.Make(code.OpConstant, 1),
+				// 0011
+				code.Make(code.OpPop),
+			},
+		},
+	}
+	runCompilerTest(t, tests)
+}
+
 func runCompilerTest(t *testing.T, tests []compilerTestCase) {
 	t.Helper()
 

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -235,6 +235,8 @@ func isTruthy(obj object.Object) bool {
 	switch obj := obj.(type) {
 	case *object.Boolean:
 		return obj.Value
+	case *object.Null:
+		return false
 	default:
 		return true
 	}

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -76,6 +76,17 @@ func (vm *VM) Run() error {
 			}
 		case code.OpPop:
 			vm.pop()
+		case code.OpJump:
+			pos := int(code.ReadUint16(vm.instructions[ip+1:]))
+			ip = pos - 1
+		case code.OpJumpNotTruthy:
+			pos := int(code.ReadUint16(vm.instructions[ip+1:]))
+			ip += 2
+
+			condition := vm.pop()
+			if !isTruthy(condition) {
+				ip = pos - 1
+			}
 		}
 	}
 	return nil
@@ -210,6 +221,15 @@ func (vm *VM) executeMinusOperator() error {
 	value := operand.(*object.Integer).Value
 	vm.push(&object.Integer{Value: -value})
 	return nil
+}
+
+func isTruthy(obj object.Object) bool {
+	switch obj := obj.(type){
+	case *object.Boolean:
+		return obj.Value
+	default:
+		return true
+	}
 }
 
 func New(bytecode *compiler.Bytecode) *VM {

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -11,6 +11,7 @@ const StackSize = 2048
 
 var True = &object.Boolean{Value: true}
 var False = &object.Boolean{Value: false}
+var Null = &object.Null{}
 
 type VM struct {
 	instructions code.Instructions
@@ -224,7 +225,7 @@ func (vm *VM) executeMinusOperator() error {
 }
 
 func isTruthy(obj object.Object) bool {
-	switch obj := obj.(type){
+	switch obj := obj.(type) {
 	case *object.Boolean:
 		return obj.Value
 	default:

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -88,6 +88,11 @@ func (vm *VM) Run() error {
 			if !isTruthy(condition) {
 				ip = pos - 1
 			}
+		case code.OpNull:
+			err := vm.push(Null)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -211,6 +211,8 @@ func (vm *VM) executeBangOperator() error {
 		return vm.push(False)
 	case False:
 		return vm.push(True)
+	case Null:
+		return vm.push(True)
 	default:
 		return vm.push(False)
 	}

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -51,7 +51,9 @@ func TestBooleanExpressions(t *testing.T) {
 		{"!false", true},
 		{"!5", false}, // In our specification, everything other than False are treated as truthy.
 		{"!!5", true},
-		{"!(if(false){ 5; })", true},
+		{"!(if(false){ 5; })", true},                // To test !Null to be treated as true
+		{"if (if(false){ 5; }) {10} else {20}", 20}, // To test nil to be treated as false
+
 	}
 	runVmTests(t, tests)
 }

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -64,9 +64,8 @@ func TestConditionals(t *testing.T) {
 		{"if (1 < 2) { 10 }", 10},
 		{"if (1 < 2) { 10 } else { 20 }", 10},
 		{"if (1 > 2) { 10 } else { 20 }", 20},
-		// TODO: Add later
-		// {"if (1 > 2) { 10 }", Null},
-		// {"if (false) { 10 }", Null},
+		{"if (1 > 2) { 10 }", Null},
+		{"if (false) { 10 }", Null},
 	}
 	runVmTests(t, tests)
 }
@@ -115,6 +114,10 @@ func testExpectedObject(t *testing.T, expected interface{}, actual object.Object
 		err := testBooleanObject(expected, actual)
 		if err != nil {
 			t.Errorf("testBooleanObject failed: %s", err)
+		}
+	case *object.Null:
+		if actual != Null {
+			t.Errorf("object is not Null: %T (%+v)", actual, actual)
 		}
 	}
 }

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -55,6 +55,22 @@ func TestBooleanExpressions(t *testing.T) {
 	runVmTests(t, tests)
 }
 
+func TestConditionals(t *testing.T) {
+	tests := []vmTestCase{
+		{"if (true) { 10 }", 10},
+		{"if (true) { 10 } else { 20 }", 10},
+		{"if (false) { 10 } else { 20 }", 20},
+		{"if (1) { 10 }", 10},
+		{"if (1 < 2) { 10 }", 10},
+		{"if (1 < 2) { 10 } else { 20 }", 10},
+		{"if (1 > 2) { 10 } else { 20 }", 20},
+		// TODO: Add later
+		// {"if (1 > 2) { 10 }", Null},
+		// {"if (false) { 10 }", Null},
+	}
+	runVmTests(t, tests)
+}
+
 /*
 Tests the top element in the stack.
 */

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -51,6 +51,7 @@ func TestBooleanExpressions(t *testing.T) {
 		{"!false", true},
 		{"!5", false}, // In our specification, everything other than False are treated as truthy.
 		{"!!5", true},
+		{"!(if(false){ 5; })", true},
 	}
 	runVmTests(t, tests)
 }


### PR DESCRIPTION
- Enable the compiler to compile `ast.IfExpression`
   - used the technique called `backpatching`
- Enable the vm to read these newly added opcodes (to execute if expression)
   - OpJumpNotTruthy
   - OpJump
   - OpNull