### PR TITLE
Fix `parser.parseIfExpression`

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -262,7 +262,6 @@ func (p *Parser) parseIfExpression() ast.Expression {
 		}
 		expression.Alternative = p.parseBlockStatement()
 	}
-	p.nextToken()
 
 	return expression
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -555,6 +555,59 @@ func TestIfElseExpression(t *testing.T) {
 	}
 }
 
+func TestIfElseExpressionInParenthesis(t *testing.T) {
+	input := `(if (x < y){ x }else{ y })`
+
+	l := lexer.New(input)
+	p := New(l)
+	program := p.ParseProgram()
+	checkParserErrors(t, p)
+
+	if len(program.Statements) != 1 {
+		t.Fatalf("program.Statements does not contain %d statements, got=%d\n", 1, len(program.Statements))
+	}
+
+	stmt, ok := program.Statements[0].(*ast.ExpressionStatement)
+	if !ok {
+		t.Fatalf("program.Statements[0] is not ast.ExpressionStatement, got=%T", stmt.Expression)
+	}
+
+	exp, ok := stmt.Expression.(*ast.IfExpression)
+	if !ok {
+		t.Fatalf("stmt.Expression is not ast.IfExpression, got=%T", stmt.Expression)
+	}
+
+	if !testInfixExpression(t, exp.Condition, "x", "<", "y") {
+		return
+	}
+
+	if len(exp.Consequence.Statements) != 1 {
+		t.Errorf("consequence is not 1 statements. got=%d", len(exp.Consequence.Statements))
+	}
+
+	consequence, ok := exp.Consequence.Statements[0].(*ast.ExpressionStatement)
+	if !ok {
+		t.Fatalf("Statements[0] is not ast.ExpressionStatement. got=%T", exp.Consequence.Statements[0])
+	}
+
+	if !testIdentifier(t, consequence.Expression, "x") {
+		return
+	}
+
+	if len(exp.Alternative.Statements) != 1 {
+		t.Errorf("alternative is not 1 statements. got=%d", len(exp.Consequence.Statements))
+	}
+
+	alternative, ok := exp.Alternative.Statements[0].(*ast.ExpressionStatement)
+	if !ok {
+		t.Errorf("Statements[0] is not *ast.Alternative, got=%T", exp.Alternative.Statements[0])
+	}
+
+	if !testIdentifier(t, alternative.Expression, "y") {
+		return
+	}
+}
+
 func TestFunctionalLiteralParsing(t *testing.T) {
 	input := `fn(x, y) { x + y;}`
 


### PR DESCRIPTION
## why
It has turned out that there is a bug in `parser.parseIfExpression`.

## What 

- Add a test case `parser.TestIfElseExpressionInParenthesis` (which fails at the point).
- Fix the bug in `parser.parseIfExpression` (which leads to the test pass)

