### PR TITLE
[Compiler] Chapter4: Compile and execute `let statement` and `identifier expression`

### DIFF
--- a/code/code.go
+++ b/code/code.go
@@ -27,6 +27,8 @@ const (
 	OpJumpNotTruthy
 	OpJump
 	OpNull
+	OpGetGlobal
+	OpSetGlobal
 )
 
 type Definition struct {
@@ -51,6 +53,8 @@ var definitions = map[Opcode]*Definition{
 	OpJumpNotTruthy: {"OpJumpNotTruthy", []int{2}},
 	OpJump:          {"OpJump", []int{2}},
 	OpNull:          {"OpNull", []int{}},
+	OpGetGlobal:     {"OpGetGlobal", []int{2}},
+	OpSetGlobal:     {"OpSetGlobal", []int{2}},
 }
 
 func Lookup(op byte) (*Definition, error) {

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -158,6 +158,12 @@ func (c *Compiler) Compile(node ast.Node) error {
 		}
 		symbol := c.symbolTable.Define(node.Name.Value)
 		c.emit(code.OpSetGlobal, symbol.Index)
+	case *ast.Identifier:
+		symbol, ok := c.symbolTable.Resolve(node.Value)
+		if !ok {
+			return fmt.Errorf("undefined variable %s", node.Value)
+		}
+		c.emit(code.OpGetGlobal, symbol.Index)
 	}
 	return nil
 }

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -30,6 +30,14 @@ func New() *Compiler {
 	}
 }
 
+// Used for REPL.
+func NewWithState(s *SymbolTable, constants []object.Object) *Compiler{
+	compiler := New()
+	compiler.symbolTable = s
+	compiler.constants = constants
+	return compiler
+}
+
 func (c *Compiler) Compile(node ast.Node) error {
 	switch node := node.(type) {
 	case *ast.Program:

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -12,6 +12,7 @@ type Compiler struct {
 	constants           []object.Object
 	lastInstruction     EmittedInstruction
 	previousInstruction EmittedInstruction
+	symbolTable         *SymbolTable
 }
 
 type EmittedInstruction struct {
@@ -25,6 +26,7 @@ func New() *Compiler {
 		constants:           []object.Object{},
 		lastInstruction:     EmittedInstruction{},
 		previousInstruction: EmittedInstruction{},
+		symbolTable:         NewSymbolTable(),
 	}
 }
 

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -151,6 +151,13 @@ func (c *Compiler) Compile(node ast.Node) error {
 				return err
 			}
 		}
+	case *ast.LetStatement:
+		err := c.Compile(node.Value)
+		if err != nil {
+			return err
+		}
+		symbol := c.symbolTable.Define(node.Name.Value)
+		c.emit(code.OpSetGlobal, symbol.Index)
 	}
 	return nil
 }

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -250,6 +250,54 @@ func TestConditionals(t *testing.T) {
 	runCompilerTest(t, tests)
 }
 
+func TestGlobalLetStatements(t *testing.T) {
+	tests := []compilerTestCase{
+		{
+			input: `
+			let one = 1;
+			let two = 2;
+			`,
+			expectedConstants: []interface{}{1, 2},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpSetGlobal, 0),
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpSetGlobal, 1),
+			},
+		},
+		{
+			input: `
+			let one = 1;
+			one;
+			`,
+			expectedConstants: []interface{}{1, 2},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpSetGlobal, 0),
+				code.Make(code.OpGetGlobal, 0),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input: `
+			let one = 1;
+			let two = one;
+			two;
+			`,
+			expectedConstants: []interface{}{1, 2},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpSetGlobal, 0),
+				code.Make(code.OpGetGlobal, 0),
+				code.Make(code.OpSetGlobal, 1),
+				code.Make(code.OpGetGlobal, 1),
+				code.Make(code.OpPop),
+			},
+		},
+	}
+	runCompilerTest(t, tests)
+}
+
 func runCompilerTest(t *testing.T, tests []compilerTestCase) {
 	t.Helper()
 

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -270,7 +270,7 @@ func TestGlobalLetStatements(t *testing.T) {
 			let one = 1;
 			one;
 			`,
-			expectedConstants: []interface{}{1, 2},
+			expectedConstants: []interface{}{1},
 			expectedInstructions: []code.Instructions{
 				code.Make(code.OpConstant, 0),
 				code.Make(code.OpSetGlobal, 0),
@@ -284,7 +284,7 @@ func TestGlobalLetStatements(t *testing.T) {
 			let two = one;
 			two;
 			`,
-			expectedConstants: []interface{}{1, 2},
+			expectedConstants: []interface{}{1},
 			expectedInstructions: []code.Instructions{
 				code.Make(code.OpConstant, 0),
 				code.Make(code.OpSetGlobal, 0),

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -316,6 +316,30 @@ func TestDefine(t *testing.T) {
 	}
 }
 
+func TestResolveGlobal(t *testing.T) {
+	global := NewSymbolTable()
+	global.Define("a")
+	global.Define("b")
+
+	expected := []Symbol{
+		{Name: "a", Scope: GlobalScope, Index: 0},
+		{Name: "b", Scope: GlobalScope, Index: 1},
+	}
+
+	for _, sym := range expected {
+		result, ok := global.Resolve(sym.Name)
+		if !ok {
+			t.Errorf("name %s not resolvable", sym.Name)
+		}
+		if result != sym {
+			t.Errorf(
+				"expected %s to resolve to %+v, got=%+v",
+				sym.Name, sym, result,
+			)
+		}
+	}
+}
+
 func runCompilerTest(t *testing.T, tests []compilerTestCase) {
 	t.Helper()
 

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -298,6 +298,24 @@ func TestGlobalLetStatements(t *testing.T) {
 	runCompilerTest(t, tests)
 }
 
+func TestDefine(t *testing.T) {
+	expected := map[string]Symbol{
+		"a": Symbol{Name: "a", Scope: GlobalScope, Index: 0},
+		"b": Symbol{Name: "b", Scope: GlobalScope, Index: 1},
+	}
+	global := NewSymbolTable()
+
+	a := global.Define("a")
+	if a != expected["a"] {
+		t.Errorf("expected a=%+v, got=%+v", expected["a"], a)
+	}
+
+	b := global.Define("b")
+	if b != expected["b"] {
+		t.Errorf("expected b=%+v, got=%+v", expected["b"], b)
+	}
+}
+
 func runCompilerTest(t *testing.T, tests []compilerTestCase) {
 	t.Helper()
 

--- a/compiler/symbol_table.go
+++ b/compiler/symbol_table.go
@@ -1,0 +1,23 @@
+package compiler
+
+type SymbolScope string
+
+const (
+	GlobalScope SymbolScope = "GLOBAL"
+)
+
+type Symbol struct {
+	Name  string
+	Scope SymbolScope
+	Index int
+}
+
+type SymbolTable struct {
+	store          map[string]Symbol
+	numDefinitions int
+}
+
+func NewSymbolTable() *SymbolTable {
+	s := make(map[string]Symbol)
+	return &SymbolTable{store: s}
+}

--- a/compiler/symbol_table.go
+++ b/compiler/symbol_table.go
@@ -17,6 +17,13 @@ type SymbolTable struct {
 	numDefinitions int
 }
 
+func (s *SymbolTable) Define(name string) Symbol {
+	symbol := Symbol{Name: name, Index: s.numDefinitions, Scope: GlobalScope}
+	s.store[name] = symbol
+	s.numDefinitions++
+	return symbol
+}
+
 func NewSymbolTable() *SymbolTable {
 	s := make(map[string]Symbol)
 	return &SymbolTable{store: s}

--- a/compiler/symbol_table.go
+++ b/compiler/symbol_table.go
@@ -24,6 +24,11 @@ func (s *SymbolTable) Define(name string) Symbol {
 	return symbol
 }
 
+func (s *SymbolTable) Resolve(name string) (Symbol, bool) {
+	obj, ok := s.store[name]
+	return obj, ok
+}
+
 func NewSymbolTable() *SymbolTable {
 	s := make(map[string]Symbol)
 	return &SymbolTable{store: s}

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"monkey/compiler"
 	"monkey/lexer"
+	"monkey/object"
 	"monkey/parser"
 	"monkey/vm"
 )
@@ -27,6 +28,10 @@ const MONKEY_FACE = `            __,__
 func Start(in io.Reader, out io.Writer) {
 	scanner := bufio.NewScanner(in)
 
+	constants := []object.Object{}
+	globals := make([]object.Object, vm.GlobalsSize)
+	symbolTable := compiler.NewSymbolTable()
+
 	for {
 		fmt.Fprintf(out, PROMPT)
 		scanned := scanner.Scan()
@@ -44,14 +49,17 @@ func Start(in io.Reader, out io.Writer) {
 			continue
 		}
 
-		comp := compiler.New()
+		comp := compiler.NewWithState(symbolTable, constants)
 		err := comp.Compile(program)
 		if err != nil {
 			fmt.Fprintf(out, "Woops! Compilation failed:\n %s\n", err)
 			continue
 		}
 
-		machine := vm.New(comp.ByteCode())
+		code := comp.ByteCode()
+		constants = code.Constants
+
+		machine := vm.NewWithGlobalsStore(code, globals)
 		err = machine.Run()
 		if err != nil {
 			fmt.Fprintf(out, "Woops! Executing bytecode failed:\n %s\n", err)

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -95,6 +95,17 @@ func (vm *VM) Run() error {
 			if err != nil {
 				return err
 			}
+		case code.OpSetGlobal:
+			globalIndex := code.ReadUint16(vm.instructions[ip+1:])
+			ip += 2
+			vm.globals[globalIndex] = vm.pop()
+		case code.OpGetGlobal:
+			globalIndex := code.ReadUint16(vm.instructions[ip+1:])
+			ip += 2
+			err := vm.push(vm.globals[globalIndex])
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -264,3 +264,10 @@ func New(bytecode *compiler.Bytecode) *VM {
 		sp:           0,
 	}
 }
+
+// Used for REPL
+func NewWithGlobalsStore(bytecode *compiler.Bytecode, s []object.Object) *VM {
+	vm := New(bytecode)
+	vm.globals = s
+	return vm
+}

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -8,6 +8,7 @@ import (
 )
 
 const StackSize = 2048
+const GlobalsSize = 65536
 
 var True = &object.Boolean{Value: true}
 var False = &object.Boolean{Value: false}
@@ -16,6 +17,7 @@ var Null = &object.Null{}
 type VM struct {
 	instructions code.Instructions
 	constants    []object.Object
+	globals      []object.Object
 
 	stack []object.Object
 	sp    int // Always point to the next value. Top of stack is stack[sp-1]
@@ -246,6 +248,7 @@ func New(bytecode *compiler.Bytecode) *VM {
 	return &VM{
 		instructions: bytecode.Instructions,
 		constants:    bytecode.Constants,
+		globals:      make([]object.Object, GlobalsSize),
 		stack:        make([]object.Object, StackSize),
 		sp:           0,
 	}

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -73,6 +73,15 @@ func TestConditionals(t *testing.T) {
 	runVmTests(t, tests)
 }
 
+func TestGlobalLetStatements(t *testing.T) {
+	tests := []vmTestCase{
+		{"let one = 1; one", 1},
+		{"let one = 1; let two = 2; one + two", 3},
+		{"let one = 1; let two = one + one; one + two", 3},
+	}
+	runVmTests(t, tests)
+}
+
 /*
 Tests the top element in the stack.
 */


### PR DESCRIPTION
Enable our compiler + vm to 

- Set variable with let statements
- Get value from identifier


Under the hood,,,

Compiler holds a hash named `symbolTable` whose keys are identifiers and whose values are Symbol structs. This Symbol has just an index of Global Store (slice of object.Objects). **This counter is incremented and managed in a compiler** even though objects are added to Global Store in VM. Setting/Fetching value to/from Global Store is instructed with `code.OpGetGlobal` and `code.OpSetGlobal` opcodes.

