### PR TITLE
[Compiler]Chapter6(1/3) Enable to compile `String` and their sum operation

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -31,7 +31,7 @@ func New() *Compiler {
 }
 
 // Used for REPL.
-func NewWithState(s *SymbolTable, constants []object.Object) *Compiler{
+func NewWithState(s *SymbolTable, constants []object.Object) *Compiler {
 	compiler := New()
 	compiler.symbolTable = s
 	compiler.constants = constants
@@ -107,6 +107,9 @@ func (c *Compiler) Compile(node ast.Node) error {
 	case *ast.IntegerLiteral:
 		integer := &object.Integer{Value: node.Value}
 		c.emit(code.OpConstant, c.addConstant(integer))
+	case *ast.StringLiteral:
+		str := &object.String{Value: node.Value}
+		c.emit(code.OpConstant, c.addConstant(str))
 	case *ast.Boolean:
 		if node.Value {
 			c.emit(code.OpTrue)

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -340,6 +340,30 @@ func TestResolveGlobal(t *testing.T) {
 	}
 }
 
+func TestStringExpressions(t *testing.T) {
+	tests := []compilerTestCase{
+		{
+			input:             `"monkey"`,
+			expectedConstants: []interface{}{"monkey"},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input:             `"mon" + "key"`,
+			expectedConstants: []interface{}{"mon", "key"},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpAdd),
+				code.Make(code.OpPop),
+			},
+		},
+	}
+	runCompilerTest(t, tests)
+}
+
 func runCompilerTest(t *testing.T, tests []compilerTestCase) {
 	t.Helper()
 
@@ -412,6 +436,11 @@ func testConstants(
 					i, err,
 				)
 			}
+		case string:
+			err := testStringObject(constant, actual[i])
+			if err != nil {
+				return fmt.Errorf("constant %d = tetsStringObject failed: %s", i, err)
+			}
 		}
 	}
 	return nil
@@ -431,6 +460,21 @@ func testIntegerObject(expected int64, actual object.Object) error {
 			"object has wrong value. want=%d, got=%d",
 			expected, actual,
 		)
+	}
+	return nil
+}
+
+func testStringObject(expected string, actual object.Object) error {
+	result, ok := actual.(*object.String)
+	if !ok {
+		return fmt.Errorf(
+			"object is not String. got=%T (%+v)",
+			actual, actual,
+		)
+	}
+
+	if result.Value != expected {
+		return fmt.Errorf("object has wrong value. got=%q, want=%q", result.Value, expected)
 	}
 	return nil
 }

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -134,8 +134,11 @@ func (vm *VM) executeBinaryOperation(op code.Opcode) error {
 	rightType := right.Type()
 	leftType := left.Type()
 
-	if leftType == object.INTEGER_OBJ && rightType == object.INTEGER_OBJ {
+	switch {
+	case leftType == object.INTEGER_OBJ && rightType == object.INTEGER_OBJ:
 		return vm.executeBinaryIntegerOperation(op, left, right)
+	case leftType == object.STRING_OBJ && rightType == object.STRING_OBJ:
+		return vm.executeBinaryStringOperation(op, left, right)
 	}
 
 	return fmt.Errorf(
@@ -167,6 +170,25 @@ func (vm *VM) executeBinaryIntegerOperation(
 	}
 
 	return vm.push(&object.Integer{Value: result})
+}
+
+func (vm *VM) executeBinaryStringOperation(
+	op code.Opcode,
+	left, right object.Object,
+) error {
+	leftVal := left.(*object.String).Value
+	rightVal := right.(*object.String).Value
+
+	var result string
+
+	switch op {
+	case code.OpAdd:
+		result = leftVal + rightVal
+	default:
+		return fmt.Errorf("unknown string operator: %d", op)
+	}
+
+	return vm.push(&object.String{Value: result})
 }
 
 func (vm *VM) executeComparison(op code.Opcode) error {

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -82,6 +82,15 @@ func TestGlobalLetStatements(t *testing.T) {
 	runVmTests(t, tests)
 }
 
+func TestStringExpressions(t *testing.T) {
+	tests := []vmTestCase{
+		{`"monkey"`, "monkey"},
+		{`"mon" + "key"`, "monkey"},
+		{`"mon" + "key" + "banana"`, "monkeybanana"},
+	}
+	runVmTests(t, tests)
+}
+
 /*
 Tests the top element in the stack.
 */
@@ -122,6 +131,11 @@ func testExpectedObject(t *testing.T, expected interface{}, actual object.Object
 		if err != nil {
 			t.Errorf("testIntegerObject failed: %s", err)
 		}
+	case string:
+		err := testStringObject(expected, actual)
+		if err != nil {
+			t.Errorf("testStringObject failed: %s", err)
+		}
 	case bool:
 		err := testBooleanObject(expected, actual)
 		if err != nil {
@@ -146,6 +160,24 @@ func testIntegerObject(expected int64, actual object.Object) error {
 	if result.Value != expected {
 		return fmt.Errorf(
 			"object has wrong value. want=%d, got=%d",
+			expected, result.Value,
+		)
+	}
+	return nil
+}
+
+func testStringObject(expected string, actual object.Object) error {
+	result, ok := actual.(*object.String)
+	if !ok {
+		return fmt.Errorf(
+			"object is not String. got=%T(%+v)",
+			actual, actual,
+		)
+	}
+
+	if result.Value != expected {
+		return fmt.Errorf(
+			"object has wrong value. want=%s, got=%s",
 			expected, result.Value,
 		)
 	}


### PR DESCRIPTION
- Compile `ast.StringLiteral`
- Support sum operation of String in VM (`object.STRING_OBJ`+`object.STRING_OBJ`)