### PR TITLE
[Compiler]Chapter6(1/2) Enable out compiler + VM to handle Array and Hash

### DIFF
--- a/code/code.go
+++ b/code/code.go
@@ -31,6 +31,7 @@ const (
 	OpSetGlobal
 	OpArray
 	OpHash
+	OpIndex
 )
 
 type Definition struct {
@@ -59,6 +60,7 @@ var definitions = map[Opcode]*Definition{
 	OpSetGlobal:     {"OpSetGlobal", []int{2}},
 	OpArray:         {"OpArray", []int{2}},
 	OpHash:          {"OpHash", []int{2}},
+	OpIndex:         {"OpIndex", []int{}},
 }
 
 func Lookup(op byte) (*Definition, error) {

--- a/code/code.go
+++ b/code/code.go
@@ -30,6 +30,7 @@ const (
 	OpGetGlobal
 	OpSetGlobal
 	OpArray
+	OpHash
 )
 
 type Definition struct {
@@ -57,6 +58,7 @@ var definitions = map[Opcode]*Definition{
 	OpGetGlobal:     {"OpGetGlobal", []int{2}},
 	OpSetGlobal:     {"OpSetGlobal", []int{2}},
 	OpArray:         {"OpArray", []int{2}},
+	OpHash:          {"OpHash", []int{2}},
 }
 
 func Lookup(op byte) (*Definition, error) {

--- a/code/code.go
+++ b/code/code.go
@@ -29,6 +29,7 @@ const (
 	OpNull
 	OpGetGlobal
 	OpSetGlobal
+	OpArray
 )
 
 type Definition struct {
@@ -55,6 +56,7 @@ var definitions = map[Opcode]*Definition{
 	OpNull:          {"OpNull", []int{}},
 	OpGetGlobal:     {"OpGetGlobal", []int{2}},
 	OpSetGlobal:     {"OpSetGlobal", []int{2}},
+	OpArray:         {"OpArray", []int{2}},
 }
 
 func Lookup(op byte) (*Definition, error) {

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -205,6 +205,16 @@ func (c *Compiler) Compile(node ast.Node) error {
 			}
 		}
 		c.emit(code.OpHash, len(node.Pairs)*2)
+	case *ast.IndexExpression:
+		err := c.Compile(node.Left)
+		if err != nil {
+			return err
+		}
+		err = c.Compile(node.Index)
+		if err != nil {
+			return err
+		}
+		c.emit(code.OpIndex)
 	}
 	return nil
 }

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -5,6 +5,7 @@ import (
 	"monkey/ast"
 	"monkey/code"
 	"monkey/object"
+	"sort"
 )
 
 type Compiler struct {
@@ -183,6 +184,27 @@ func (c *Compiler) Compile(node ast.Node) error {
 			}
 		}
 		c.emit(code.OpArray, len(node.Elements))
+	case *ast.HashLiteral:
+		keys := []ast.Expression{}
+		for k := range node.Pairs {
+			keys = append(keys, k)
+		}
+		// For testing purpose, we would like to order keys of the hash in a consistent order.
+		sort.Slice(
+			keys,
+			func(i, j int) bool { return keys[i].String() < keys[j].String() },
+		)
+		for _, k := range keys {
+			err := c.Compile(k)
+			if err != nil {
+				return err
+			}
+			err = c.Compile(node.Pairs[k])
+			if err != nil {
+				return err
+			}
+		}
+		c.emit(code.OpHash, len(node.Pairs)*2)
 	}
 	return nil
 }

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -175,6 +175,14 @@ func (c *Compiler) Compile(node ast.Node) error {
 			return fmt.Errorf("undefined variable %s", node.Value)
 		}
 		c.emit(code.OpGetGlobal, symbol.Index)
+	case *ast.ArrayLiteral:
+		for _, el := range node.Elements {
+			err := c.Compile(el)
+			if err != nil {
+				return err
+			}
+		}
+		c.emit(code.OpArray, len(node.Elements))
 	}
 	return nil
 }

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -450,6 +450,41 @@ func TestHashLiteral(t *testing.T) {
 	runCompilerTest(t, tests)
 }
 
+func TestIndexExpressions(t *testing.T) {
+	tests := []compilerTestCase{
+		{
+			input:             "[1,2,3][1+1]",
+			expectedConstants: []interface{}{1, 2, 3, 1, 1},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpConstant, 2),
+				code.Make(code.OpArray, 3),
+				code.Make(code.OpConstant, 3),
+				code.Make(code.OpConstant, 4),
+				code.Make(code.OpAdd),
+				code.Make(code.OpIndex),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input:             "{1: 2}[2-1]",
+			expectedConstants: []interface{}{1, 2, 2, 1},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpHash, 2),
+				code.Make(code.OpConstant, 2),
+				code.Make(code.OpConstant, 3),
+				code.Make(code.OpSub),
+				code.Make(code.OpIndex),
+				code.Make(code.OpPop),
+			},
+		},
+	}
+	runCompilerTest(t, tests)
+}
+
 func runCompilerTest(t *testing.T, tests []compilerTestCase) {
 	t.Helper()
 

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -364,6 +364,48 @@ func TestStringExpressions(t *testing.T) {
 	runCompilerTest(t, tests)
 }
 
+func TestArrayLiterals(t *testing.T) {
+	tests := []compilerTestCase{
+		{
+			input:             "[]",
+			expectedConstants: []interface{}{},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpArray, 0),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input:             "[1, 2, 3]",
+			expectedConstants: []interface{}{1, 2, 3},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpConstant, 2),
+				code.Make(code.OpArray, 3),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input:             "[1+2, 3-4, 5*6]",
+			expectedConstants: []interface{}{1, 2, 3, 4, 5, 6},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpAdd),
+				code.Make(code.OpConstant, 2),
+				code.Make(code.OpConstant, 3),
+				code.Make(code.OpSub),
+				code.Make(code.OpConstant, 4),
+				code.Make(code.OpConstant, 5),
+				code.Make(code.OpMul),
+				code.Make(code.OpArray, 3),
+				code.Make(code.OpPop),
+			},
+		},
+	}
+	runCompilerTest(t, tests)
+}
+
 func runCompilerTest(t *testing.T, tests []compilerTestCase) {
 	t.Helper()
 

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -406,6 +406,50 @@ func TestArrayLiterals(t *testing.T) {
 	runCompilerTest(t, tests)
 }
 
+func TestHashLiteral(t *testing.T) {
+	tests := []compilerTestCase{
+		{
+			input:             "{}",
+			expectedConstants: []interface{}{},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpHash, 0),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input:             "{1: 2, 3: 4, 5: 6}",
+			expectedConstants: []interface{}{1, 2, 3, 4, 5, 6},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpConstant, 2),
+				code.Make(code.OpConstant, 3),
+				code.Make(code.OpConstant, 4),
+				code.Make(code.OpConstant, 5),
+				code.Make(code.OpHash, 6),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input:             "{1: 2+3, 4: 5*6}",
+			expectedConstants: []interface{}{1, 2, 3, 4, 5, 6},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpConstant, 2),
+				code.Make(code.OpAdd),
+				code.Make(code.OpConstant, 3),
+				code.Make(code.OpConstant, 4),
+				code.Make(code.OpConstant, 5),
+				code.Make(code.OpMul),
+				code.Make(code.OpHash, 4),
+				code.Make(code.OpPop),
+			},
+		},
+	}
+	runCompilerTest(t, tests)
+}
+
 func runCompilerTest(t *testing.T, tests []compilerTestCase) {
 	t.Helper()
 

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -116,17 +116,48 @@ func (vm *VM) Run() error {
 			if err != nil {
 				return err
 			}
+		case code.OpHash:
+			numElements := int(code.ReadUint16(vm.instructions[ip+1:]))
+			ip += 2
+
+			hash, err := vm.buildHash(vm.sp-numElements, vm.sp)
+			if err != nil {
+				return err
+			}
+			vm.sp = vm.sp - numElements
+			err = vm.push(hash)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return nil
 }
 
-func (vm *VM) buildArray(startIndex, endIndex int) object.Object{
-	elements := make([]object.Object, endIndex - startIndex)
-	for i := startIndex; i < endIndex; i++{
+func (vm *VM) buildArray(startIndex, endIndex int) object.Object {
+	elements := make([]object.Object, endIndex-startIndex)
+	for i := startIndex; i < endIndex; i++ {
 		elements[i-startIndex] = vm.stack[i]
 	}
 	return &object.Array{Elements: elements}
+}
+
+func (vm *VM) buildHash(startIndex, endIndex int) (object.Object, error) {
+	hashedPairs := make(map[object.HashKey]object.HashPair)
+
+	for i := startIndex; i < endIndex; i += 2 {
+		key := vm.stack[i]
+		value := vm.stack[i+1]
+		pair := object.HashPair{Key: key, Value: value}
+
+		hashableKey, ok := key.(object.Hashable)
+		if !ok {
+			return nil, fmt.Errorf("unusable as a hash key: %s", key.Type())
+		}
+
+		hashedPairs[hashableKey.HashKey()] = pair
+	}
+	return &object.Hash{Pairs: hashedPairs}, nil
 }
 
 func (vm *VM) push(o object.Object) error {

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -106,9 +106,27 @@ func (vm *VM) Run() error {
 			if err != nil {
 				return err
 			}
+		case code.OpArray:
+			numElements := int(code.ReadUint16(vm.instructions[ip+1:]))
+			ip += 2
+
+			array := vm.buildArray(vm.sp-numElements, vm.sp)
+			vm.sp = vm.sp - numElements
+			err := vm.push(array)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return nil
+}
+
+func (vm *VM) buildArray(startIndex, endIndex int) object.Object{
+	elements := make([]object.Object, endIndex - startIndex)
+	for i := startIndex; i < endIndex; i++{
+		elements[i-startIndex] = vm.stack[i]
+	}
+	return &object.Array{Elements: elements}
 }
 
 func (vm *VM) push(o object.Object) error {

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -91,6 +91,15 @@ func TestStringExpressions(t *testing.T) {
 	runVmTests(t, tests)
 }
 
+func TestArrayLiterals(t *testing.T) {
+	tests := []vmTestCase{
+		{"[]", []int{}},
+		{"[1,2,3]", []int{1, 2, 3}},
+		{"[1+2, 3*4, 5+6]", []int{3, 12, 11}},
+	}
+	runVmTests(t, tests)
+}
+
 /*
 Tests the top element in the stack.
 */
@@ -144,6 +153,27 @@ func testExpectedObject(t *testing.T, expected interface{}, actual object.Object
 	case *object.Null:
 		if actual != Null {
 			t.Errorf("object is not Null: %T (%+v)", actual, actual)
+		}
+	case []int:
+		array, ok := actual.(*object.Array)
+		if !ok {
+			t.Errorf("object not Array: %T (%+v)", actual, actual)
+			return
+		}
+
+		if len(array.Elements) != len(expected) {
+			t.Errorf(
+				"wrong num of elements. want=%d, got=%d",
+				len(expected), len(array.Elements),
+			)
+			return
+		}
+
+		for i, expectedElem := range expected {
+			err := testIntegerObject(int64(expectedElem), array.Elements[i])
+			if err != nil {
+				t.Errorf("testIntegerObject failed %s", err)
+			}
 		}
 	}
 }

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -123,6 +123,28 @@ func TestHashLiterals(t *testing.T) {
 	runVmTests(t, tests)
 }
 
+func TestArrayIndexExpressions(t *testing.T) {
+	tests := []vmTestCase{
+		{"[1,2,3][1]", 2},
+		{"[1,2,3][0+2]", 3},
+		{"[[1,1,1]][0][0]", 1},
+		{"[][0]", Null},
+		{"[1,2,3][3]", Null},
+		{"[1][-1]", Null},
+	}
+	runVmTests(t, tests)
+}
+
+func TestHashIndexExpressions(t *testing.T) {
+	tests := []vmTestCase{
+		{"{1:1, 2:2}[1]", 1},
+		{"{1:1, 2:2}[2]", 2},
+		{"{1: 1}[0]", Null},
+		{"{}[0]", Null},
+	}
+	runVmTests(t, tests)
+}
+
 /*
 Tests the top element in the stack.
 */

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -100,6 +100,29 @@ func TestArrayLiterals(t *testing.T) {
 	runVmTests(t, tests)
 }
 
+func TestHashLiterals(t *testing.T) {
+	tests := []vmTestCase{
+		{
+			"{}", map[object.HashKey]int64{},
+		},
+		{
+			"{1: 2, 2: 3}",
+			map[object.HashKey]int64{
+				(&object.Integer{Value: 1}).HashKey(): 2,
+				(&object.Integer{Value: 2}).HashKey(): 3,
+			},
+		},
+		{
+			"{1+1: 2*2, 3+3: 4*4}",
+			map[object.HashKey]int64{
+				(&object.Integer{Value: 2}).HashKey(): 4,
+				(&object.Integer{Value: 6}).HashKey(): 16,
+			},
+		},
+	}
+	runVmTests(t, tests)
+}
+
 /*
 Tests the top element in the stack.
 */
@@ -173,6 +196,28 @@ func testExpectedObject(t *testing.T, expected interface{}, actual object.Object
 			err := testIntegerObject(int64(expectedElem), array.Elements[i])
 			if err != nil {
 				t.Errorf("testIntegerObject failed %s", err)
+			}
+		}
+	case map[object.HashKey]int64:
+		hash, ok := actual.(*object.Hash)
+		if !ok{
+			t.Errorf("object is not Hash. got=%T(%+v)", actual, actual)
+			return
+		}
+		if len(hash.Pairs) != len(expected){
+			t.Errorf(
+				"hash has wrong number of Pairs. want=%d, got=%d",
+				len(expected), len(hash.Pairs),
+			)
+		}
+		for expectedKey, expectedValue := range expected{
+			pair, ok := hash.Pairs[expectedKey]
+			if !ok{
+				t.Errorf("no pair for given key in Pairs.")
+			}
+			err := testIntegerObject(expectedValue, pair.Value)
+			if err != nil {
+				t.Errorf("testIntegerObject failed: %s", err)
 			}
 		}
 	}

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -200,19 +200,19 @@ func testExpectedObject(t *testing.T, expected interface{}, actual object.Object
 		}
 	case map[object.HashKey]int64:
 		hash, ok := actual.(*object.Hash)
-		if !ok{
+		if !ok {
 			t.Errorf("object is not Hash. got=%T(%+v)", actual, actual)
 			return
 		}
-		if len(hash.Pairs) != len(expected){
+		if len(hash.Pairs) != len(expected) {
 			t.Errorf(
 				"hash has wrong number of Pairs. want=%d, got=%d",
 				len(expected), len(hash.Pairs),
 			)
 		}
-		for expectedKey, expectedValue := range expected{
+		for expectedKey, expectedValue := range expected {
 			pair, ok := hash.Pairs[expectedKey]
-			if !ok{
+			if !ok {
 				t.Errorf("no pair for given key in Pairs.")
 			}
 			err := testIntegerObject(expectedValue, pair.Value)


### PR DESCRIPTION
### Array

- Enable our compiler to compile array literals
- Enable our vm to read OpArray and to generate object.Array.
- Enable out vm to read OpIndex and get the corresponding element from object.OpArray

### Hash


- Enable our compiler to compile hash literals.
- Enable our vm to read OpHash and to generate object.Hash.
- Enable out vm to read OpIndex and get the corresponding element from object.OpHash