### PR TITLE
[Compiler]Chapter7(1/2): Compile and execute functions

### DIFF
--- a/code/code.go
+++ b/code/code.go
@@ -32,6 +32,7 @@ const (
 	OpArray
 	OpHash
 	OpIndex
+	OpCall
 )
 
 type Definition struct {
@@ -61,6 +62,7 @@ var definitions = map[Opcode]*Definition{
 	OpArray:         {"OpArray", []int{2}},
 	OpHash:          {"OpHash", []int{2}},
 	OpIndex:         {"OpIndex", []int{}},
+	OpCall:          {"OpCall", []int{}},
 }
 
 func Lookup(op byte) (*Definition, error) {

--- a/code/code.go
+++ b/code/code.go
@@ -34,6 +34,7 @@ const (
 	OpIndex
 	OpCall
 	OpReturnValue
+	OpReturn
 )
 
 type Definition struct {
@@ -65,6 +66,7 @@ var definitions = map[Opcode]*Definition{
 	OpIndex:         {"OpIndex", []int{}},
 	OpCall:          {"OpCall", []int{}},
 	OpReturnValue:   {"OpReturnValue", []int{}},
+	OpReturn:        {"OpReturn", []int{}},
 }
 
 func Lookup(op byte) (*Definition, error) {

--- a/code/code.go
+++ b/code/code.go
@@ -33,6 +33,7 @@ const (
 	OpHash
 	OpIndex
 	OpCall
+	OpReturnValue
 )
 
 type Definition struct {
@@ -63,6 +64,7 @@ var definitions = map[Opcode]*Definition{
 	OpHash:          {"OpHash", []int{2}},
 	OpIndex:         {"OpIndex", []int{}},
 	OpCall:          {"OpCall", []int{}},
+	OpReturnValue:   {"OpReturnValue", []int{}},
 }
 
 func Lookup(op byte) (*Definition, error) {

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -249,6 +249,10 @@ func (c *Compiler) Compile(node ast.Node) error {
 		if err != nil {
 			return err
 		}
+		// For implicit return
+		if c.lastInstructionIs(code.OpPop) {
+			c.replaceLastPopWithReturn()
+		}
 		instructions := c.leaveScope()
 
 		compiledFn := &object.CompiledFunction{Instructions: instructions}
@@ -336,6 +340,13 @@ func (c *Compiler) replaceInstruction(pos int, newInstruction []byte) {
 	for i := 0; i < len(newInstruction); i++ {
 		ins[pos+i] = newInstruction[i]
 	}
+}
+
+func (c *Compiler) replaceLastPopWithReturn() {
+	lastPos := c.scopes[c.scopeIndex].lastInstruction.Position
+	c.replaceInstruction(lastPos, code.Make(code.OpReturnValue))
+
+	c.scopes[c.scopeIndex].lastInstruction.Opcode = code.OpReturnValue
 }
 
 type Bytecode struct {

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -243,6 +243,16 @@ func (c *Compiler) Compile(node ast.Node) error {
 			return err
 		}
 		c.emit(code.OpIndex)
+	case *ast.FunctionLiteral:
+		c.enterScope()
+		err := c.Compile(node.Body)
+		if err != nil{
+			return err
+		}
+		instructions := c.leaveScope()
+
+		compiledFn := &object.CompiledFunction{Instructions: instructions}
+		c.emit(code.OpConstant, c.addConstant(compiledFn))
 	}
 	return nil
 }

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -9,13 +9,11 @@ import (
 )
 
 type Compiler struct {
-	instructions        code.Instructions
-	constants           []object.Object
-	lastInstruction     EmittedInstruction
-	previousInstruction EmittedInstruction
-	symbolTable         *SymbolTable
-	scopes              []CompilationScope
-	scopeIndex          int
+	instructions code.Instructions
+	constants    []object.Object
+	symbolTable  *SymbolTable
+	scopes       []CompilationScope
+	scopeIndex   int
 }
 
 type CompilationScope struct {
@@ -30,12 +28,17 @@ type EmittedInstruction struct {
 }
 
 func New() *Compiler {
-	return &Compiler{
+	mainScope := CompilationScope{
 		instructions:        code.Instructions{},
-		constants:           []object.Object{},
 		lastInstruction:     EmittedInstruction{},
 		previousInstruction: EmittedInstruction{},
-		symbolTable:         NewSymbolTable(),
+	}
+
+	return &Compiler{
+		constants:   []object.Object{},
+		symbolTable: NewSymbolTable(),
+		scopes:      []CompilationScope{mainScope},
+		scopeIndex:  0,
 	}
 }
 

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -268,6 +268,12 @@ func (c *Compiler) Compile(node ast.Node) error {
 			return err
 		}
 		c.emit(code.OpReturnValue)
+	case *ast.CallExpression:
+		err := c.Compile(node.Function)
+		if err != nil {
+			return err
+		}
+		c.emit(code.OpCall)
 	}
 	return nil
 }

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -47,6 +47,9 @@ func NewWithState(s *SymbolTable, constants []object.Object) *Compiler {
 	return compiler
 }
 
+func (c *Compiler) enterScope()                   {}             // TODO
+func (c *Compiler) leaveScope() code.Instructions { return nil } // TODO
+
 func (c *Compiler) Compile(node ast.Node) error {
 	switch node := node.(type) {
 	case *ast.Program:

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -246,7 +246,7 @@ func (c *Compiler) Compile(node ast.Node) error {
 	case *ast.FunctionLiteral:
 		c.enterScope()
 		err := c.Compile(node.Body)
-		if err != nil{
+		if err != nil {
 			return err
 		}
 		instructions := c.leaveScope()
@@ -255,7 +255,7 @@ func (c *Compiler) Compile(node ast.Node) error {
 		c.emit(code.OpConstant, c.addConstant(compiledFn))
 	case *ast.ReturnStatement:
 		err := c.Compile(node.ReturnValue)
-		if err != nil{
+		if err != nil {
 			return err
 		}
 		c.emit(code.OpReturnValue)

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -253,6 +253,12 @@ func (c *Compiler) Compile(node ast.Node) error {
 
 		compiledFn := &object.CompiledFunction{Instructions: instructions}
 		c.emit(code.OpConstant, c.addConstant(compiledFn))
+	case *ast.ReturnStatement:
+		err := c.Compile(node.ReturnValue)
+		if err != nil{
+			return err
+		}
+		c.emit(code.OpReturnValue)
 	}
 	return nil
 }

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -249,10 +249,15 @@ func (c *Compiler) Compile(node ast.Node) error {
 		if err != nil {
 			return err
 		}
-		// For implicit return
+		// when implicit return
 		if c.lastInstructionIs(code.OpPop) {
 			c.replaceLastPopWithReturn()
 		}
+		// when nothing to be returned (neither implicit return nor explicit return)
+		if !c.lastInstructionIs(code.OpReturnValue) {
+			c.emit(code.OpReturn)
+		}
+
 		instructions := c.leaveScope()
 
 		compiledFn := &object.CompiledFunction{Instructions: instructions}

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -14,6 +14,14 @@ type Compiler struct {
 	lastInstruction     EmittedInstruction
 	previousInstruction EmittedInstruction
 	symbolTable         *SymbolTable
+	scopes              []CompilationScope
+	scopeIndex          int
+}
+
+type CompilationScope struct {
+	instructions        code.Instructions
+	lastInstruction     EmittedInstruction
+	previousInstruction EmittedInstruction
 }
 
 type EmittedInstruction struct {

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -49,8 +49,23 @@ func NewWithState(s *SymbolTable, constants []object.Object) *Compiler {
 	return compiler
 }
 
-func (c *Compiler) enterScope()                   {}             // TODO
-func (c *Compiler) leaveScope() code.Instructions { return nil } // TODO
+func (c *Compiler) enterScope() {
+	scope := CompilationScope{
+		instructions:        code.Instructions{},
+		lastInstruction:     EmittedInstruction{},
+		previousInstruction: EmittedInstruction{},
+	}
+	c.scopes = append(c.scopes, scope)
+	c.scopeIndex++
+}
+
+func (c *Compiler) leaveScope() code.Instructions {
+	instructions := c.currentInstructions()
+
+	c.scopes = c.scopes[:len(c.scopes)-1]
+	c.scopeIndex--
+	return instructions
+}
 
 func (c *Compiler) Compile(node ast.Node) error {
 	switch node := node.(type) {

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -160,7 +160,7 @@ func (c *Compiler) Compile(node ast.Node) error {
 			return err
 		}
 
-		if c.lastInstructionIsPop() {
+		if c.lastInstructionIs(code.OpPop) {
 			c.removeLastPop()
 		}
 
@@ -178,7 +178,7 @@ func (c *Compiler) Compile(node ast.Node) error {
 			if err != nil {
 				return err
 			}
-			if c.lastInstructionIsPop() {
+			if c.lastInstructionIs(code.OpPop) {
 				c.removeLastPop()
 			}
 		}
@@ -304,8 +304,11 @@ func (c *Compiler) setLastInstruction(op code.Opcode, pos int) {
 	c.scopes[c.scopeIndex].lastInstruction = last
 }
 
-func (c *Compiler) lastInstructionIsPop() bool {
-	return c.scopes[c.scopeIndex].lastInstruction.Opcode == code.OpPop
+func (c *Compiler) lastInstructionIs(op code.Opcode) bool {
+	if len(c.currentInstructions()) == 0 {
+		return false
+	}
+	return c.scopes[c.scopeIndex].lastInstruction.Opcode == op
 }
 
 func (c *Compiler) removeLastPop() {

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -606,6 +606,47 @@ func TestCompilerScopes(t *testing.T) {
 	}
 }
 
+func TestFunctionCalls(t *testing.T) {
+	tests := []compilerTestCase{
+		{
+			input: `fn(){24}()`,
+			expectedConstants: []interface{}{
+				24,
+				[]code.Instructions{
+					code.Make(code.OpConstant, 0), // The literal `24`
+					code.Make(code.OpReturnValue),
+				},
+			},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpCall),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input: `
+			let noArg = fn(){24};
+			noArg()
+			`,
+			expectedConstants: []interface{}{
+				24,
+				[]code.Instructions{
+					code.Make(code.OpConstant, 0), // The literal `24`
+					code.Make(code.OpReturnValue),
+				},
+			},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 1), // The compiled function
+				code.Make(code.OpSetGlobal, 0),
+				code.Make(code.OpGetGlobal, 0),
+				code.Make(code.OpCall),
+				code.Make(code.OpPop),
+			},
+		},
+	}
+	runCompilerTest(t, tests)
+}
+
 func runCompilerTest(t *testing.T, tests []compilerTestCase) {
 	t.Helper()
 

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -485,6 +485,29 @@ func TestIndexExpressions(t *testing.T) {
 	runCompilerTest(t, tests)
 }
 
+func TestFunctions(t *testing.T) {
+	tests := []compilerTestCase{
+		{
+			input: `fn(){return 5 + 10}`,
+			expectedConstants: []interface{}{
+				5,
+				10,
+				[]code.Instructions{
+					code.Make(code.OpConstant, 0),
+					code.Make(code.OpConstant, 1),
+					code.Make(code.OpAdd),
+					code.Make(code.OpReturnValue),
+				},
+			},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 2),
+				code.Make(code.OpPop),
+			},
+		},
+	}
+	runCompilerTest(t, tests)
+}
+
 func runCompilerTest(t *testing.T, tests []compilerTestCase) {
 	t.Helper()
 
@@ -561,6 +584,21 @@ func testConstants(
 			err := testStringObject(constant, actual[i])
 			if err != nil {
 				return fmt.Errorf("constant %d = tetsStringObject failed: %s", i, err)
+			}
+		case []code.Instructions:
+			fn, ok := actual[i].(*object.CompiledFunction)
+			if !ok {
+				return fmt.Errorf(
+					"constant %d - not a function: %T",
+					i, actual[i],
+				)
+			}
+			err := testInstructions(constant, fn.Instructions)
+			if err != nil {
+				return fmt.Errorf(
+					"constant %d - testInstructions failded: %s",
+					i, err,
+				)
 			}
 		}
 	}

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -488,7 +488,7 @@ func TestIndexExpressions(t *testing.T) {
 func TestFunctions(t *testing.T) {
 	tests := []compilerTestCase{
 		{
-			input: `fn(){return 5 + 10}`,
+			input: `fn(){return 5 + 10}`, // explicit return
 			expectedConstants: []interface{}{
 				5,
 				10,
@@ -496,6 +496,40 @@ func TestFunctions(t *testing.T) {
 					code.Make(code.OpConstant, 0),
 					code.Make(code.OpConstant, 1),
 					code.Make(code.OpAdd),
+					code.Make(code.OpReturnValue),
+				},
+			},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 2),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input: `fn(){5 + 10}`, // implicit return
+			expectedConstants: []interface{}{
+				5,
+				10,
+				[]code.Instructions{
+					code.Make(code.OpConstant, 0),
+					code.Make(code.OpConstant, 1),
+					code.Make(code.OpAdd),
+					code.Make(code.OpReturnValue),
+				},
+			},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 2),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input: `fn(){1; 2}`, // implicit return
+			expectedConstants: []interface{}{
+				1,
+				2,
+				[]code.Instructions{
+					code.Make(code.OpConstant, 0),
+					code.Make(code.OpPop),
+					code.Make(code.OpConstant, 1),
 					code.Make(code.OpReturnValue),
 				},
 			},

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -538,6 +538,18 @@ func TestFunctions(t *testing.T) {
 				code.Make(code.OpPop),
 			},
 		},
+		{
+			input: `fn(){}`, // there's nothing to be returned.
+			expectedConstants: []interface{}{
+				[]code.Instructions{
+					code.Make(code.OpReturn),
+				},
+			},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpPop),
+			},
+		},
 	}
 	runCompilerTest(t, tests)
 }

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -682,7 +682,7 @@ func testConstants(
 			err := testInstructions(constant, fn.Instructions)
 			if err != nil {
 				return fmt.Errorf(
-					"constant %d - testInstructions failded: %s",
+					"constant %d - testInstructions failed: %s",
 					i, err,
 				)
 			}

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -555,7 +555,7 @@ func TestCompilerScopes(t *testing.T) {
 	}
 
 	prev := compiler.scopes[compiler.scopeIndex].previousInstruction
-	if prev.Opcode != code.OpAdd {
+	if prev.Opcode != code.OpMul {
 		t.Errorf("lastInstruction.Opcode wrong. got=%d, want=%d", last.Opcode, code.OpAdd)
 	}
 }

--- a/object/object.go
+++ b/object/object.go
@@ -5,22 +5,24 @@ import (
 	"fmt"
 	"hash/fnv"
 	"monkey/ast"
+	"monkey/code"
 	"strings"
 )
 
 type ObjectType string
 
 const (
-	INTEGER_OBJ      = "INTEGER"
-	BOOLEAN_OBJ      = "BOOLEAN"
-	NULL_OBJ         = "NULL"
-	RETURN_VALUE_OBJ = "RETURN_VALUE"
-	FUNCTION_OBJ     = "FUNCTION"
-	ERROR_OBJ        = "ERROR"
-	STRING_OBJ       = "STRING"
-	BUILT_IN_OBJ     = "BUILTIN"
-	ARRAY_OBJ        = "ARRAY"
-	HASH_OBJ         = "HASH"
+	INTEGER_OBJ           = "INTEGER"
+	BOOLEAN_OBJ           = "BOOLEAN"
+	NULL_OBJ              = "NULL"
+	RETURN_VALUE_OBJ      = "RETURN_VALUE"
+	FUNCTION_OBJ          = "FUNCTION"
+	ERROR_OBJ             = "ERROR"
+	STRING_OBJ            = "STRING"
+	BUILT_IN_OBJ          = "BUILTIN"
+	ARRAY_OBJ             = "ARRAY"
+	HASH_OBJ              = "HASH"
+	COMPILED_FUNCTION_OBJ = "COMPILED_FUNCTION_OBJ"
 )
 
 type Object interface {
@@ -164,6 +166,13 @@ type HashPair struct {
 type Hashable interface {
 	HashKey() HashKey
 }
+
+type CompiledFunction struct {
+	Instructions code.Instructions
+}
+
+func (cf *CompiledFunction) Type() ObjectType { return COMPILED_FUNCTION_OBJ }
+func (cf *CompiledFunction) Inspect() string { return fmt.Sprintf("CompiledFunction[%p]", cf)}
 
 type Error struct {
 	Message string

--- a/vm/frame.go
+++ b/vm/frame.go
@@ -1,0 +1,19 @@
+package vm
+
+import (
+	"monkey/code"
+	"monkey/object"
+)
+
+type Frame struct {
+	fn *object.CompiledFunction
+	ip int
+}
+
+func NewFrame(fn *object.CompiledFunction) *Frame {
+	return &Frame{fn: fn, ip: -1}
+}
+
+func (f *Frame) Instructions() code.Instructions {
+	return f.fn.Instructions
+}

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -38,6 +38,9 @@ type VM struct {
 
 	stack []object.Object
 	sp    int // Always point to the next value. Top of stack is stack[sp-1]
+
+	frames      []*Frame
+	framesIndex int
 }
 
 func (vm *VM) StackTop() object.Object {
@@ -384,4 +387,17 @@ func (vm *VM) executeHashIndex(hash, key object.Object) error {
 		return vm.push(Null)
 	}
 	return vm.push(pair.Value)
+}
+
+func (vm *VM) currentFrame() *Frame {
+	return vm.frames[vm.framesIndex-1]
+}
+
+func (vm *VM) pushFrame(f *Frame) {
+	vm.frames[vm.framesIndex] = f
+	vm.framesIndex++
+}
+
+func (vm *VM) popFrame() {
+	vm.framesIndex--
 }

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -179,6 +179,15 @@ func (vm *VM) Run() error {
 			}
 			frame := NewFrame(fn)
 			vm.pushFrame(frame)
+		case code.OpReturnValue:
+			returnValue := vm.pop()
+			vm.popFrame() // go back to the caller of the current function
+			vm.pop()
+
+			err := vm.push(returnValue)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -172,6 +172,13 @@ func (vm *VM) Run() error {
 			if err != nil {
 				return err
 			}
+		case code.OpCall:
+			fn, ok := vm.stack[vm.sp-1].(*object.CompiledFunction)
+			if !ok {
+				return fmt.Errorf("calling non-function")
+			}
+			frame := NewFrame(fn)
+			vm.pushFrame(frame)
 		}
 	}
 	return nil

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -188,6 +188,13 @@ func (vm *VM) Run() error {
 			if err != nil {
 				return err
 			}
+		case code.OpReturn:
+			vm.popFrame()
+			vm.pop()
+			err := vm.push(Null)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -195,6 +195,28 @@ func TestCallingFunctionsWithReturnStatements(t *testing.T) {
 	runVmTests(t, tests)
 }
 
+func TestCallingFunctionsWithoutReturnValue(t *testing.T) {
+	tests := []vmTestCase{
+		{
+			input: `
+			let noReturn = fn(){};
+			noReturn()
+			`,
+			expected: Null,
+		},
+		{
+			input: `
+			let noReturn = fn(){};
+			let noReturnTwo = fn(){ noReturn() };
+			noReturn();
+			noReturnTwo();
+			`,
+			expected: Null,
+		},
+	}
+	runVmTests(t, tests)
+}
+
 /*
 Tests the top element in the stack.
 */

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -175,6 +175,26 @@ func TestCallingFunctionsWithoutArguments(t *testing.T) {
 	runVmTests(t, tests)
 }
 
+func TestCallingFunctionsWithReturnStatements(t *testing.T) {
+	tests := []vmTestCase{
+		{
+			input: `
+			let earlyExit = fn(){return 99; 100;};
+			earlyExit()
+			`,
+			expected: 99,
+		},
+		{
+			input: `
+			let earlyExit = fn(){return 99; return 100;};
+			earlyExit()
+			`,
+			expected: 99,
+		},
+	}
+	runVmTests(t, tests)
+}
+
 /*
 Tests the top element in the stack.
 */

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -145,6 +145,19 @@ func TestHashIndexExpressions(t *testing.T) {
 	runVmTests(t, tests)
 }
 
+func TestCallingFunctionsWithoutArguments(t *testing.T) {
+	tests := []vmTestCase{
+		{
+			input: `
+			let fivePlusTen = fn() {5+10;};
+			fivePlusTen();
+			`,
+			expected: 15,
+		},
+	}
+	runVmTests(t, tests)
+}
+
 /*
 Tests the top element in the stack.
 */

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -154,6 +154,23 @@ func TestCallingFunctionsWithoutArguments(t *testing.T) {
 			`,
 			expected: 15,
 		},
+		{
+			input: `
+			let one = fn(){1;};
+			let two = fn(){2;};
+			one() + two()
+			`,
+			expected: 3,
+		},
+		{
+			input: `
+			let a = fn(){1};
+			let b = fn(){a()+1};
+			let c = fn(){b()+1};
+			c();
+			`,
+			expected: 3,
+		},
 	}
 	runVmTests(t, tests)
 }

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -217,6 +217,20 @@ func TestCallingFunctionsWithoutReturnValue(t *testing.T) {
 	runVmTests(t, tests)
 }
 
+func TestFirstClassFunctions(t *testing.T) {
+	tests := []vmTestCase{
+		{
+			input: `
+			let returnsOne = fn(){1;};
+			let returnsOneReturner = fn(){ returnsOne; };
+			returnsOneReturner()();
+			`,
+			expected: 1,
+		},
+	}
+	runVmTests(t, tests)
+}
+
 /*
 Tests the top element in the stack.
 */


### PR DESCRIPTION
## Why

To enable our compiler to compile and our VM to execute a function with theses features.

- does not have local bindings
- called without arguments
- does not access global bindings

## What

### `code` package

- Define new opcodes: `OpCall`, `OpReturnValue`, `OpReturn`
   - `OpReturnValue` is used for implicit/explicit returns from a function.
   - `OpReturn` is used when there is nothing to be returned from a function.
   -  function is considered as a constant with its function body as bytecode.

### `compiler` package

- Define `CompilationScope` which corresponds to each function 
   - In the process of compiling, compiler `enterScope`s when executing a function and `leaveScope`s when it's done.
   - `instructions`(=byte code), `lastInstruction`, `previousInstruction` are now held in this struct.
   - main method is also considered as a special CompilerScope.
   - Compiler has many `CompilationScope`s in its slice.

### `object` package

- Define `object.COMPILED_FUNCTION_OBJ`
   - CompiledFunctionObj has its function body as `Instructions`(=byte code)

### `vm` package


- Add a `Frame Stack` (as frames) and define `Frame` used as the elements. 
   - A `Frame` is created for each function call.
   - vm has one frame stack.
   - Frame holds bytecode (of corresponding function) and instruction pointer(= current index) int the bytecode.
   - When encountering `Opcall` bytecode, vm creates a new frame and put it on the top of call stack. When encountering  `OpReturn` or `OpReturnValue`, it pops out current frame from the callstack.