### PR TITLE
[Compiler]Chapter7(2/3): Compile and execute functions with local bindings

### DIFF
--- a/code/code.go
+++ b/code/code.go
@@ -133,7 +133,7 @@ func Make(op Opcode, operands ...int) []byte {
 	}
 
 	instructionLen := 1
-	for _, w := range def.OperandWidths {
+	for _, w := range def.OperandWidths { // operand(s) of one opcode can be multiple.
 		instructionLen += w
 	}
 
@@ -144,9 +144,12 @@ func Make(op Opcode, operands ...int) []byte {
 	for i, o := range operands {
 		width := def.OperandWidths[i]
 		switch width {
+		case 1:
+			instruction[offset] = byte(o)
 		case 2:
 			binary.BigEndian.PutUint16(instruction[offset:], uint16(o))
 		}
+		offset += width
 	}
 	return instruction
 }

--- a/code/code.go
+++ b/code/code.go
@@ -161,6 +161,8 @@ func ReadOperands(def *Definition, ins Instructions) ([]int, int) {
 
 	for i, width := range def.OperandWidths {
 		switch width {
+		case 1:
+			operands[i] = int(ReadUint8(ins[offset : offset+width]))
 		case 2:
 			operands[i] = int(ReadUint16(ins[offset : offset+width]))
 		}
@@ -168,6 +170,10 @@ func ReadOperands(def *Definition, ins Instructions) ([]int, int) {
 	}
 
 	return operands, offset
+}
+
+func ReadUint8(ins Instructions) uint8 {
+	return uint8(ins[0])
 }
 
 func ReadUint16(ins Instructions) uint16 {

--- a/code/code.go
+++ b/code/code.go
@@ -35,6 +35,8 @@ const (
 	OpCall
 	OpReturnValue
 	OpReturn
+	OpGetLocal
+	OpSetLocal
 )
 
 type Definition struct {
@@ -67,6 +69,8 @@ var definitions = map[Opcode]*Definition{
 	OpCall:          {"OpCall", []int{}},
 	OpReturnValue:   {"OpReturnValue", []int{}},
 	OpReturn:        {"OpReturn", []int{}},
+	OpGetLocal:      {"OpGetLocal", []int{1}},
+	OpSetLocal:      {"OpSetLocal", []int{1}},
 }
 
 func Lookup(op byte) (*Definition, error) {

--- a/code/code_test.go
+++ b/code/code_test.go
@@ -67,6 +67,7 @@ func TestReadOperands(t *testing.T) {
 	}{
 		{OpConstant, []int{65535}, 2},
 		{OpAdd, []int{}, 0},
+		{OpGetLocal, []int{255}, 1},
 	}
 
 	for _, tt := range tests {

--- a/code/code_test.go
+++ b/code/code_test.go
@@ -37,13 +37,15 @@ func TestMake(t *testing.T) {
 func TestInstructionsString(t *testing.T) {
 	instructions := []Instructions{
 		Make(OpAdd),
+		Make(OpGetLocal, 1),
 		Make(OpConstant, 2),
 		Make(OpConstant, 65535),
 	}
 
 	expected := `0000 OpAdd
-0001 OpConstant 2
-0004 OpConstant 65535
+0001 OpGetLocal 1
+0003 OpConstant 2
+0006 OpConstant 65535
 `
 
 	concatted := Instructions{} // array of byte arrays

--- a/code/code_test.go
+++ b/code/code_test.go
@@ -9,6 +9,7 @@ func TestMake(t *testing.T) {
 		expected []byte
 	}{
 		{OpConstant, []int{65534}, []byte{byte(OpConstant), 255, 254}},
+		{OpGetLocal, []int{255}, []byte{byte(OpGetLocal), 255}},
 	}
 
 	for _, tt := range tests {

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -209,7 +209,11 @@ func (c *Compiler) Compile(node ast.Node) error {
 		if !ok {
 			return fmt.Errorf("undefined variable %s", node.Value)
 		}
-		c.emit(code.OpGetGlobal, symbol.Index)
+		if symbol.Scope == GlobalScope {
+			c.emit(code.OpGetGlobal, symbol.Index)
+		} else {
+			c.emit(code.OpGetLocal, symbol.Index)
+		}
 	case *ast.ArrayLiteral:
 		for _, el := range node.Elements {
 			err := c.Compile(el)

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -199,7 +199,11 @@ func (c *Compiler) Compile(node ast.Node) error {
 			return err
 		}
 		symbol := c.symbolTable.Define(node.Name.Value)
-		c.emit(code.OpSetGlobal, symbol.Index)
+		if symbol.Scope == GlobalScope {
+			c.emit(code.OpSetGlobal, symbol.Index)
+		} else {
+			c.emit(code.OpSetLocal, symbol.Index)
+		}
 	case *ast.Identifier:
 		symbol, ok := c.symbolTable.Resolve(node.Value)
 		if !ok {

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -267,10 +267,13 @@ func (c *Compiler) Compile(node ast.Node) error {
 		if !c.lastInstructionIs(code.OpReturnValue) {
 			c.emit(code.OpReturn)
 		}
-
+		numLocals := c.symbolTable.numDefinitions
 		instructions := c.leaveScope()
 
-		compiledFn := &object.CompiledFunction{Instructions: instructions}
+		compiledFn := &object.CompiledFunction{
+			Instructions: instructions,
+			NumLocals:    numLocals,
+		}
 		c.emit(code.OpConstant, c.addConstant(compiledFn))
 	case *ast.ReturnStatement:
 		err := c.Compile(node.ReturnValue)

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -57,6 +57,7 @@ func (c *Compiler) enterScope() {
 	}
 	c.scopes = append(c.scopes, scope)
 	c.scopeIndex++
+	c.symbolTable = NewEnclosedSymbolTable(c.symbolTable)
 }
 
 func (c *Compiler) leaveScope() code.Instructions {
@@ -64,6 +65,7 @@ func (c *Compiler) leaveScope() code.Instructions {
 
 	c.scopes = c.scopes[:len(c.scopes)-1]
 	c.scopeIndex--
+	c.symbolTable = c.symbolTable.Outer
 	return instructions
 }
 

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -517,8 +517,10 @@ func TestCompilerScopes(t *testing.T) {
 	if compiler.scopeIndex != 0 {
 		t.Errorf("scopeIndex wrong. got=%d, want=%d", compiler.scopeIndex, 0) // index 0 = scope of main method
 	}
+	globalSymbolTable := compiler.symbolTable
 	compiler.emit(code.OpMul)
 
+	// Enter
 	compiler.enterScope()
 	if compiler.scopeIndex != 1 {
 		t.Errorf("scopeIndex wrong. got=%d, want=%d", compiler.scopeIndex, 1)
@@ -540,9 +542,22 @@ func TestCompilerScopes(t *testing.T) {
 		)
 	}
 
+	if compiler.symbolTable.Outer != globalSymbolTable {
+		t.Errorf("compiler did not enclose symbolTable.")
+	}
+
+	// Leave
 	compiler.leaveScope()
 	if compiler.scopeIndex != 0 {
 		t.Errorf("scopeIndex wrong. got=%d, want=%d", compiler.scopeIndex, 0)
+	}
+
+	if compiler.symbolTable != globalSymbolTable {
+		t.Errorf("compiler did not restore global symbol table")
+	}
+
+	if compiler.symbolTable.Outer != nil {
+		t.Errorf("compiler modifed global symbol table incorrectly.")
 	}
 
 	compiler.emit(code.OpAdd)

--- a/compiler/symbol_table.go
+++ b/compiler/symbol_table.go
@@ -34,7 +34,10 @@ func (s *SymbolTable) Define(name string) Symbol {
 
 func (s *SymbolTable) Resolve(name string) (Symbol, bool) {
 	obj, ok := s.store[name]
-	return obj, ok
+	if s.Outer == nil || ok {
+		return obj, ok
+	}
+	return s.Outer.Resolve(name)
 }
 
 func NewSymbolTable() *SymbolTable {

--- a/compiler/symbol_table.go
+++ b/compiler/symbol_table.go
@@ -20,7 +20,13 @@ type SymbolTable struct {
 }
 
 func (s *SymbolTable) Define(name string) Symbol {
-	symbol := Symbol{Name: name, Index: s.numDefinitions, Scope: GlobalScope}
+	symbol := Symbol{Name: name, Index: s.numDefinitions}
+	if s.Outer == nil {
+		symbol.Scope = GlobalScope
+	} else {
+		symbol.Scope = LocalScope
+	}
+
 	s.store[name] = symbol
 	s.numDefinitions++
 	return symbol

--- a/compiler/symbol_table.go
+++ b/compiler/symbol_table.go
@@ -13,6 +13,7 @@ type Symbol struct {
 }
 
 type SymbolTable struct {
+	Outer          *SymbolTable
 	store          map[string]Symbol
 	numDefinitions int
 }
@@ -32,4 +33,10 @@ func (s *SymbolTable) Resolve(name string) (Symbol, bool) {
 func NewSymbolTable() *SymbolTable {
 	s := make(map[string]Symbol)
 	return &SymbolTable{store: s}
+}
+
+func NewEnclosedSymbolTable(outer *SymbolTable) *SymbolTable {
+	s := NewSymbolTable()
+	s.Outer = outer
+	return s
 }

--- a/compiler/symbol_table.go
+++ b/compiler/symbol_table.go
@@ -4,6 +4,7 @@ type SymbolScope string
 
 const (
 	GlobalScope SymbolScope = "GLOBAL"
+	LocalScope  SymbolScope = "LOCAL"
 )
 
 type Symbol struct {

--- a/compiler/symbol_table_test.go
+++ b/compiler/symbol_table_test.go
@@ -43,3 +43,32 @@ func TestResolveGlobal(t *testing.T) {
 		}
 	}
 }
+
+func TestResolveLocal(t *testing.T) {
+	global := NewSymbolTable()
+	global.Define("a")
+	global.Define("b")
+
+	local := NewEnclosedSymbolTable(global)
+	local.Define("c")
+	local.Define("d")
+
+	expected := []Symbol{
+		Symbol{Name: "a", Scope: GlobalScope, Index: 0},
+		Symbol{Name: "b", Scope: GlobalScope, Index: 1},
+		Symbol{Name: "c", Scope: LocalScope, Index: 0},
+		Symbol{Name: "d", Scope: LocalScope, Index: 1},
+	}
+
+	for _, sym := range expected {
+		result, ok := local.Resolve(sym.Name)
+		if !ok {
+			t.Errorf("name %s not resolvable", sym.Name)
+			continue
+		}
+
+		if result != sym {
+			t.Errorf("expected %s to resolve to %+v, got=%+v", sym.Name, sym, result)
+		}
+	}
+}

--- a/compiler/symbol_table_test.go
+++ b/compiler/symbol_table_test.go
@@ -72,3 +72,54 @@ func TestResolveLocal(t *testing.T) {
 		}
 	}
 }
+
+func TestResolveNestedLocal(t *testing.T) {
+	global := NewSymbolTable()
+	global.Define("a")
+	global.Define("b")
+
+	firstLocal := NewEnclosedSymbolTable(global)
+	firstLocal.Define("c")
+	firstLocal.Define("d")
+
+	secondLocal := NewEnclosedSymbolTable(firstLocal)
+	secondLocal.Define("e")
+	secondLocal.Define("f")
+
+	tests := []struct {
+		table           *SymbolTable
+		expectedSymbols []Symbol
+	}{
+		{
+			firstLocal,
+			[]Symbol{
+				{Name: "a", Scope: GlobalScope, Index: 0},
+				{Name: "b", Scope: GlobalScope, Index: 1},
+				{Name: "c", Scope: LocalScope, Index: 0},
+				{Name: "d", Scope: LocalScope, Index: 1},
+			},
+		},
+		{
+			secondLocal,
+			[]Symbol{
+				{Name: "a", Scope: GlobalScope, Index: 0},
+				{Name: "b", Scope: GlobalScope, Index: 1},
+				{Name: "e", Scope: LocalScope, Index: 0},
+				{Name: "f", Scope: LocalScope, Index: 1},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		for _, sym := range tt.expectedSymbols {
+			result, ok := tt.table.Resolve(sym.Name)
+			if !ok {
+				t.Errorf("name %s not resolvable", sym.Name)
+				continue
+			}
+			if result != sym {
+				t.Errorf("expected %s to resolve to %+v, got=%+v", sym.Name, sym, result)
+			}
+		}
+	}
+}

--- a/compiler/symbol_table_test.go
+++ b/compiler/symbol_table_test.go
@@ -6,6 +6,10 @@ func TestDefine(t *testing.T) {
 	expected := map[string]Symbol{
 		"a": {Name: "a", Scope: GlobalScope, Index: 0},
 		"b": {Name: "b", Scope: GlobalScope, Index: 1},
+		"c": {Name: "c", Scope: LocalScope, Index: 0},
+		"d": {Name: "d", Scope: LocalScope, Index: 1},
+		"e": {Name: "e", Scope: LocalScope, Index: 0},
+		"f": {Name: "f", Scope: LocalScope, Index: 1},
 	}
 	global := NewSymbolTable()
 
@@ -17,6 +21,30 @@ func TestDefine(t *testing.T) {
 	b := global.Define("b")
 	if b != expected["b"] {
 		t.Errorf("expected b=%+v, got=%+v", expected["b"], b)
+	}
+
+	firstLocal := NewEnclosedSymbolTable(global)
+
+	c := firstLocal.Define("c")
+	if c != expected["c"] {
+		t.Errorf("expected c=%+v, got=%+v", expected["c"], c)
+	}
+
+	d := firstLocal.Define("d")
+	if d != expected["d"] {
+		t.Errorf("expected d=%+v, got=%+v", expected["d"], d)
+	}
+
+	secondLocal := NewEnclosedSymbolTable(firstLocal)
+
+	e := secondLocal.Define("e")
+	if e != expected["e"] {
+		t.Errorf("expected e=%+v, got=%+v", expected["e"], e)
+	}
+
+	f := secondLocal.Define("f")
+	if f != expected["f"] {
+		t.Errorf("expected f=%+v, got=%+v", expected["f"], f)
 	}
 }
 

--- a/object/object.go
+++ b/object/object.go
@@ -169,6 +169,7 @@ type Hashable interface {
 
 type CompiledFunction struct {
 	Instructions code.Instructions
+	numLocals    int
 }
 
 func (cf *CompiledFunction) Type() ObjectType { return COMPILED_FUNCTION_OBJ }

--- a/object/object.go
+++ b/object/object.go
@@ -172,7 +172,7 @@ type CompiledFunction struct {
 }
 
 func (cf *CompiledFunction) Type() ObjectType { return COMPILED_FUNCTION_OBJ }
-func (cf *CompiledFunction) Inspect() string { return fmt.Sprintf("CompiledFunction[%p]", cf)}
+func (cf *CompiledFunction) Inspect() string  { return fmt.Sprintf("CompiledFunction[%p]", cf) }
 
 type Error struct {
 	Message string

--- a/object/object.go
+++ b/object/object.go
@@ -169,7 +169,7 @@ type Hashable interface {
 
 type CompiledFunction struct {
 	Instructions code.Instructions
-	numLocals    int
+	NumLocals    int
 }
 
 func (cf *CompiledFunction) Type() ObjectType { return COMPILED_FUNCTION_OBJ }

--- a/vm/frame.go
+++ b/vm/frame.go
@@ -6,12 +6,17 @@ import (
 )
 
 type Frame struct {
-	fn *object.CompiledFunction
-	ip int
+	fn          *object.CompiledFunction
+	ip          int
+	basePointer int
 }
 
-func NewFrame(fn *object.CompiledFunction) *Frame {
-	return &Frame{fn: fn, ip: -1}
+func NewFrame(fn *object.CompiledFunction, basePointer int) *Frame {
+	return &Frame{
+		fn: fn,
+		ip: -1,
+		basePointer: basePointer,
+	}
 }
 
 func (f *Frame) Instructions() code.Instructions {

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -142,6 +142,19 @@ func (vm *VM) Run() error {
 			if err != nil {
 				return err
 			}
+		case code.OpSetLocal:
+			localIndex := code.ReadUint8(ins[ip+1:])
+			vm.currentFrame().ip += 1
+			frame := vm.currentFrame()
+			vm.stack[frame.basePointer+int(localIndex)] = vm.pop()
+		case code.OpGetLocal:
+			localIndex := code.ReadUint8(ins[ip+1:])
+			vm.currentFrame().ip += 1
+			frame := vm.currentFrame()
+			err := vm.push(vm.stack[frame.basePointer+int(localIndex)])
+			if err != nil {
+				return err
+			}
 		case code.OpArray:
 			numElements := int(code.ReadUint16(ins[ip+1:]))
 			vm.currentFrame().ip += 2

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -177,8 +177,9 @@ func (vm *VM) Run() error {
 			if !ok {
 				return fmt.Errorf("calling non-function")
 			}
-			frame := NewFrame(fn)
+			frame := NewFrame(fn, vm.sp)
 			vm.pushFrame(frame)
+			vm.sp = frame.basePointer + fn.NumLocals
 		case code.OpReturnValue:
 			returnValue := vm.pop()
 			vm.popFrame() // go back to the caller of the current function

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -195,7 +195,8 @@ func (vm *VM) Run() error {
 			vm.sp = frame.basePointer + fn.NumLocals
 		case code.OpReturnValue:
 			returnValue := vm.pop()
-			vm.popFrame() // go back to the caller of the current function
+			frame := vm.popFrame() // go back to the caller of the current function
+			vm.sp = frame.basePointer
 			vm.pop()
 
 			err := vm.push(returnValue)
@@ -203,7 +204,8 @@ func (vm *VM) Run() error {
 				return err
 			}
 		case code.OpReturn:
-			vm.popFrame()
+			frame := vm.popFrame()
+			vm.sp = frame.basePointer
 			vm.pop()
 			err := vm.push(Null)
 			if err != nil {

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -451,6 +451,11 @@ func (vm *VM) pushFrame(f *Frame) {
 	vm.framesIndex++
 }
 
-func (vm *VM) popFrame() {
+/*
+Pop out current frame. Returns a frame which has been popped out.
+*/
+func (vm *VM) popFrame() *Frame {
+	lastFrame := vm.currentFrame()
 	vm.framesIndex--
+	return lastFrame
 }

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -17,7 +17,7 @@ var Null = &object.Null{}
 
 func New(bytecode *compiler.Bytecode) *VM {
 	mainFn := &object.CompiledFunction{Instructions: bytecode.Instructions}
-	mainFrame := NewFrame(mainFn)
+	mainFrame := NewFrame(mainFn, 0)
 
 	frames := make([]*Frame, MaxFrames)
 	frames[0] = mainFrame

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -196,17 +196,14 @@ func (vm *VM) Run() error {
 		case code.OpReturnValue:
 			returnValue := vm.pop()
 			frame := vm.popFrame() // go back to the caller of the current function
-			vm.sp = frame.basePointer
-			vm.pop()
-
+			vm.sp = frame.basePointer - 1
 			err := vm.push(returnValue)
 			if err != nil {
 				return err
 			}
 		case code.OpReturn:
 			frame := vm.popFrame()
-			vm.sp = frame.basePointer
-			vm.pop()
+			vm.sp = frame.basePointer - 1
 			err := vm.push(Null)
 			if err != nil {
 				return err

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -248,7 +248,7 @@ func TestCallingFunctionsWithBindings(t *testing.T) {
 			// Test that same named local bindings do not affect each other.
 			input: `
 			let firstFooBar = fn(){ let FooBar = 50; FooBar; };
-			let secondFooBar = fn(){ let FooBar = 100; Foobar; };
+			let secondFooBar = fn(){ let FooBar = 100; FooBar; };
 			firstFooBar() + secondFooBar();
 			`,
 			expected: 150,

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -217,6 +217,61 @@ func TestCallingFunctionsWithoutReturnValue(t *testing.T) {
 	runVmTests(t, tests)
 }
 
+func TestCallingFunctionsWithBindings(t *testing.T) {
+	tests := []vmTestCase{
+		{
+			// Test that local binding works in a first place.
+			input: `
+			let one = fn() { let one = 1; one };
+			one();
+			`,
+			expected: 1,
+		},
+		{
+			// Test multiple local bindings in one function.
+			input: `
+			let oneAndTwo = fn(){ let one = 1; let two = 2; one + two };
+			oneAndTwo()
+			`,
+			expected: 3,
+		},
+		{
+			// Test multiple bindings in different functions.
+			input: `
+			let oneAndTwo = fn(){ let one = 1; let two = 2; one + two };
+			let threeAndFour = fn(){ let three = 3; let four = 4; three + four };
+			oneAndTwo() + threeAndFour();
+			`,
+			expected: 10,
+		},
+		{
+			// Test that same named local bindings do not affect each other.
+			input: `
+			let firstFooBar = fn(){ let FooBar = 50; FooBar; };
+			let secondFooBar = fn(){ let FooBar = 100; Foobar; };
+			firstFooBar() + secondFooBar();
+			`,
+			expected: 150,
+		},
+		{
+			input: `
+			let globalSeed = 50;
+			let minusOne = fn(){
+				let num = 1;
+				globalSeed - num;
+			}
+			let minusTwo = fn(){
+				let num = 2;
+				globalSeed - num;
+			}
+			minusOne() + minusTwo()
+			`,
+			expected: 97,
+		},
+	}
+	runVmTests(t, tests)
+}
+
 func TestFirstClassFunctions(t *testing.T) {
 	tests := []vmTestCase{
 		{


### PR DESCRIPTION
## Why

To enable our compiler to compile and our VM to execute a function with local bindings.

```js
let global = 1
let minusOne = fn(){
    let num = 1      // local binding here.
    globalSeed = num;
}
minusOne()
```

## What

### `code` package

- Add opcodes: `OpGetLocal`, `OpSetLocal`.

### `compiler` package

- Make `SymbolTable` to be a nested structure.
- When resolving bindings, traverse SymbolTable from current one to the outmost one.

### `object` package

- Hold number of local bindings as `NumLocals` in `object.CompiledFunction`

### `vm` package

- Hold `basePointer` (also known as `fame pointer`) in the Frame which points to the bottom of the stack of the current call frame.