### PR TITLE
[Compiler]Chapter7(3/3): Compile and execute functions with arguments

### DIFF
--- a/code/code.go
+++ b/code/code.go
@@ -66,7 +66,7 @@ var definitions = map[Opcode]*Definition{
 	OpArray:         {"OpArray", []int{2}},
 	OpHash:          {"OpHash", []int{2}},
 	OpIndex:         {"OpIndex", []int{}},
-	OpCall:          {"OpCall", []int{}},
+	OpCall:          {"OpCall", []int{1}}, // An operand stands number of arguments.
 	OpReturnValue:   {"OpReturnValue", []int{}},
 	OpReturn:        {"OpReturn", []int{}},
 	OpGetLocal:      {"OpGetLocal", []int{1}},

--- a/code/code.go
+++ b/code/code.go
@@ -66,7 +66,7 @@ var definitions = map[Opcode]*Definition{
 	OpArray:         {"OpArray", []int{2}},
 	OpHash:          {"OpHash", []int{2}},
 	OpIndex:         {"OpIndex", []int{}},
-	OpCall:          {"OpCall", []int{1}}, // An operand stands number of arguments.
+	OpCall:          {"OpCall", []int{1}}, // An operand stands for number of arguments.
 	OpReturnValue:   {"OpReturnValue", []int{}},
 	OpReturn:        {"OpReturn", []int{}},
 	OpGetLocal:      {"OpGetLocal", []int{1}},

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -286,7 +286,14 @@ func (c *Compiler) Compile(node ast.Node) error {
 		if err != nil {
 			return err
 		}
-		c.emit(code.OpCall)
+
+		for _, a := range node.Arguments {
+			err := c.Compile(a)
+			if err != nil {
+				return err
+			}
+		}
+		c.emit(code.OpCall, len(node.Arguments))
 	}
 	return nil
 }

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -255,6 +255,12 @@ func (c *Compiler) Compile(node ast.Node) error {
 		c.emit(code.OpIndex)
 	case *ast.FunctionLiteral:
 		c.enterScope()
+		for _, p := range node.Parameters {
+			// Arguments are already put on the bottom of the stack by the caller before calling this function.
+			// So we just have to reserve the indexes here.
+			c.symbolTable.Define(p.Value)
+		}
+
 		err := c.Compile(node.Body)
 		if err != nil {
 			return err

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -277,8 +277,9 @@ func (c *Compiler) Compile(node ast.Node) error {
 		instructions := c.leaveScope()
 
 		compiledFn := &object.CompiledFunction{
-			Instructions: instructions,
-			NumLocals:    numLocals,
+			Instructions:  instructions,
+			NumLocals:     numLocals,
+			NumParameters: len(node.Parameters),
 		}
 		c.emit(code.OpConstant, c.addConstant(compiledFn))
 	case *ast.ReturnStatement:

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -616,6 +616,52 @@ func TestFunctionCalls(t *testing.T) {
 				code.Make(code.OpPop),
 			},
 		},
+		{
+			// Defining/Calling a function with an argument.
+			input: `
+			let oneArg = fn(a){};
+			oneArg(24);
+			`,
+			expectedConstants: []interface{}{
+				[]code.Instructions{
+					code.Make(code.OpReturn),
+				},
+				24,
+			},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpSetGlobal, 0),
+				code.Make(code.OpGetGlobal, 0),
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpCall, 1),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			// Defining/Calling a function with multiple arguments.
+			input: `
+			let manyArg = fn(a, b, c){};
+			manyArg(24, 25, 26);
+			`,
+			expectedConstants: []interface{}{
+				[]code.Instructions{
+					code.Make(code.OpReturn),
+				},
+				24,
+				25,
+				26,
+			},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpSetGlobal, 0),
+				code.Make(code.OpGetGlobal, 0),
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpConstant, 2),
+				code.Make(code.OpConstant, 3),
+				code.Make(code.OpCall, 3),
+				code.Make(code.OpPop),
+			},
+		},
 	}
 	runCompilerTest(t, tests)
 }

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -662,6 +662,58 @@ func TestFunctionCalls(t *testing.T) {
 				code.Make(code.OpPop),
 			},
 		},
+		{
+			// Define/Call a function with an argument and use it in the funcion body.
+			input: `
+			let oneArg = fn(a){a};
+			oneArg(24);
+			`,
+			expectedConstants: []interface{}{
+				[]code.Instructions{
+					code.Make(code.OpGetLocal, 0),
+					code.Make(code.OpReturnValue),
+				},
+				24,
+			},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpSetGlobal, 0),
+				code.Make(code.OpGetGlobal, 0),
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpCall, 1),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			// Define/Call a function with multiple arguments and use it in the funcion body.
+			input: `
+			let oneArg = fn(a, b, c){a; b; c};
+			oneArg(24, 25, 26);
+			`,
+			expectedConstants: []interface{}{
+				[]code.Instructions{
+					code.Make(code.OpGetLocal, 0),
+					code.Make(code.OpPop),
+					code.Make(code.OpGetLocal, 1),
+					code.Make(code.OpPop),
+					code.Make(code.OpGetLocal, 2),
+					code.Make(code.OpReturnValue),
+				},
+				24,
+				25,
+				26,
+			},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpSetGlobal, 0),
+				code.Make(code.OpGetGlobal, 0),
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpConstant, 2),
+				code.Make(code.OpConstant, 3),
+				code.Make(code.OpCall, 3),
+				code.Make(code.OpPop),
+			},
+		},
 	}
 	runCompilerTest(t, tests)
 }

--- a/object/object.go
+++ b/object/object.go
@@ -168,8 +168,9 @@ type Hashable interface {
 }
 
 type CompiledFunction struct {
-	Instructions code.Instructions
-	NumLocals    int
+	Instructions  code.Instructions
+	NumLocals     int
+	NumParameters int
 }
 
 func (cf *CompiledFunction) Type() ObjectType { return COMPILED_FUNCTION_OBJ }

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -447,6 +447,10 @@ func (vm *VM) callFunction(numArgs int) error {
 		return fmt.Errorf("calling non-function")
 	}
 
+	if fn.NumParameters != numArgs {
+		return fmt.Errorf("wrong number of arguments: want=%d, got=%d", fn.NumParameters, numArgs)
+	}
+
 	frame := NewFrame(fn, vm.sp-numArgs)
 	vm.pushFrame(frame)
 	vm.sp = frame.basePointer + fn.NumLocals

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -288,6 +288,16 @@ func TestCallingFunctionsWithArgumentsAndBindings(t *testing.T) {
 			`,
 			expected: 3,
 		},
+		{
+			input: `
+			let globalNum = 10;
+
+			let sum = fn(a, b){ let c = a + b; c + globalNum; };
+			let outer = fn() { sum(1, 2) + sum(3, 4) + globalNum; };
+			outer() + globalNum;
+			`,
+			expected: 50,
+		},
 	}
 	runVmTests(t, tests)
 }

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -302,6 +302,43 @@ func TestCallingFunctionsWithArgumentsAndBindings(t *testing.T) {
 	runVmTests(t, tests)
 }
 
+func TestCallingFunctionsWithWrongNumberOfArguments(t *testing.T) {
+	tests := []vmTestCase{
+		{
+			input:    `fn() { 1; }(1);`,
+			expected: `wrong number of arguments: want=0, got=1`,
+		},
+		{
+			input:    `fn(a) { a; }();`,
+			expected: `wrong number of arguments: want=1, got=0`,
+		},
+		{
+			input:    `fn(a, b) { a + b; }(1);`,
+			expected: `wrong number of arguments: want=2, got=1`,
+		},
+	}
+	for _, tt := range tests {
+		program := parse(tt.input)
+		comp := compiler.New()
+
+		err := comp.Compile(program)
+		if err != nil {
+			t.Fatalf("compiler error: %s", err)
+		}
+
+		vm := New(comp.ByteCode())
+		err = vm.Run()
+
+		if err == nil {
+			t.Fatalf("expected VM error but resulted in none.")
+		}
+
+		if err.Error() != tt.expected {
+			t.Fatalf("wrong VM error: want=%q, got=%q", tt.expected, err)
+		}
+	}
+}
+
 func TestFirstClassFunctions(t *testing.T) {
 	tests := []vmTestCase{
 		{

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -272,6 +272,26 @@ func TestCallingFunctionsWithBindings(t *testing.T) {
 	runVmTests(t, tests)
 }
 
+func TestCallingFunctionsWithArgumentsAndBindings(t *testing.T) {
+	tests := []vmTestCase{
+		{
+			input: `
+			let identity = fn(a){ a; }
+			identity(4)
+			`,
+			expected: 4,
+		},
+		{
+			input: `
+			let sum = fn(a, b){ a + b; };
+			sum(1, 2);
+			`,
+			expected: 3,
+		},
+	}
+	runVmTests(t, tests)
+}
+
 func TestFirstClassFunctions(t *testing.T) {
 	tests := []vmTestCase{
 		{


### PR DESCRIPTION
## Why

To enable our compiler to compile and our VM to execute a function with local bindings.

```js
let minusOne = fn(num){
    return num - 1;
}
minusOne(10)

> 9
```

## What

### `code` package

- Update opcode `OpCall` to have one operand which stands for the number of arguments.

### `compiler` package


When compiling  a function literal, 

- Reserve first indexes (0 ~ N-1) for arguments in a symbolTable of the **called** function.
- Count number of parameters and save it in `object.CompiledFunction` as `NumParameters` field.

When calling a function, 

- Emit instructions of each parameters before emitting `CallExpression` instructions.

### `object` package

- Add a field `NumParameters` in an `object.CompiledFunction` struct (which is set when compiling).

### `vm` package

When encountering `OpCall` instructions,

- Put objects (corresponding to arguments) on the stack after the `CompiledFunction` object which should have already been put.
- Consider those arguments as local variables and set the base pointer of a frame corresponding to the **called** function to `vm.sp-numArgs`.

Note that the first N indexes of the symbol table is reserved for arguments. Certainly, on the stack, arguments are put on the first N indexes from the base pointer of the called function.
