### PR TITLE
[Compiler]Chapter8: Compile and execute builtin functions

### DIFF
--- a/code/code.go
+++ b/code/code.go
@@ -37,6 +37,7 @@ const (
 	OpReturn
 	OpGetLocal
 	OpSetLocal
+	OpGetBuiltin
 )
 
 type Definition struct {
@@ -71,6 +72,7 @@ var definitions = map[Opcode]*Definition{
 	OpReturn:        {"OpReturn", []int{}},
 	OpGetLocal:      {"OpGetLocal", []int{1}},
 	OpSetLocal:      {"OpSetLocal", []int{1}},
+	OpGetBuiltin:    {"OpGetBuiltin", []int{1}},
 }
 
 func Lookup(op byte) (*Definition, error) {

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -33,9 +33,15 @@ func New() *Compiler {
 		previousInstruction: EmittedInstruction{},
 	}
 
+	symbolTable := NewSymbolTable()
+
+	for i, v := range object.Builtins {
+		symbolTable.DefineBuiltin(i, v.Name)
+	}
+
 	return &Compiler{
 		constants:   []object.Object{},
-		symbolTable: NewSymbolTable(),
+		symbolTable: symbolTable,
 		scopes:      []CompilationScope{mainScope},
 		scopeIndex:  0,
 	}

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -215,14 +215,7 @@ func (c *Compiler) Compile(node ast.Node) error {
 		if !ok {
 			return fmt.Errorf("undefined variable %s", node.Value)
 		}
-		switch symbol.Scope {
-		case GlobalScope:
-			c.emit(code.OpGetGlobal, symbol.Index)
-		case LocalScope:
-			c.emit(code.OpGetLocal, symbol.Index)
-		case BuiltinScope:
-			c.emit(code.OpGetBuiltin, symbol.Index)
-		}
+		c.loadSymbol(symbol)
 	case *ast.ArrayLiteral:
 		for _, el := range node.Elements {
 			err := c.Compile(el)
@@ -394,6 +387,17 @@ func (c *Compiler) replaceLastPopWithReturn() {
 	c.replaceInstruction(lastPos, code.Make(code.OpReturnValue))
 
 	c.scopes[c.scopeIndex].lastInstruction.Opcode = code.OpReturnValue
+}
+
+func (c *Compiler) loadSymbol(symbol Symbol) {
+	switch symbol.Scope {
+	case GlobalScope:
+		c.emit(code.OpGetGlobal, symbol.Index)
+	case LocalScope:
+		c.emit(code.OpGetLocal, symbol.Index)
+	case BuiltinScope:
+		c.emit(code.OpGetBuiltin, symbol.Index)
+	}
 }
 
 type Bytecode struct {

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -215,10 +215,13 @@ func (c *Compiler) Compile(node ast.Node) error {
 		if !ok {
 			return fmt.Errorf("undefined variable %s", node.Value)
 		}
-		if symbol.Scope == GlobalScope {
+		switch symbol.Scope {
+		case GlobalScope:
 			c.emit(code.OpGetGlobal, symbol.Index)
-		} else {
+		case LocalScope:
 			c.emit(code.OpGetLocal, symbol.Index)
+		case BuiltinScope:
+			c.emit(code.OpGetBuiltin, symbol.Index)
 		}
 	case *ast.ArrayLiteral:
 		for _, el := range node.Elements {

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -791,6 +791,45 @@ func TestLetStatementScopes(t *testing.T) {
 	runCompilerTest(t, tests)
 }
 
+func TestBuiltins(t *testing.T) {
+	tests := []compilerTestCase{
+		{
+			input: `
+			len([]);
+			push([], 1);
+			`,
+			expectedConstants: []interface{}{
+				1,
+			},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpGetBuiltin, 0),
+				code.Make(code.OpArray, 0),
+				code.Make(code.OpCall, 1),
+				code.Make(code.OpPop),
+				code.Make(code.OpGetBuiltin, 5),
+				code.Make(code.OpArray, 0),
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpCall, 2),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input: `fn(){len([])}'`,
+			expectedConstants: []interface{}{
+				code.Make(code.OpGetBuiltin, 0),
+				code.Make(code.OpArray, 0),
+				code.Make(code.OpCall, 1),
+				code.Make(code.OpReturnValue),
+			},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpPop),
+			},
+		},
+	}
+	runCompilerTest(t, tests)
+}
+
 func runCompilerTest(t *testing.T, tests []compilerTestCase) {
 	t.Helper()
 

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -830,6 +830,36 @@ func TestBuiltins(t *testing.T) {
 	runCompilerTest(t, tests)
 }
 
+func TestDefineResolveBuiltins(t *testing.T) {
+	global := NewSymbolTable()
+	firstLocal := NewEnclosedSymbolTable(global)
+	secondLocal := NewEnclosedSymbolTable(firstLocal)
+
+	expected := []Symbol{
+		Symbol{Name: "a", Scope: BuiltinScope, Index: 0},
+		Symbol{Name: "c", Scope: BuiltinScope, Index: 1},
+		Symbol{Name: "e", Scope: BuiltinScope, Index: 2},
+		Symbol{Name: "f", Scope: BuiltinScope, Index: 3},
+	}
+
+	for i, v := range expected {
+		global.DefineBuiltin(i, v.Name)
+	}
+
+	for _, table := range []*SymbolTable{global, firstLocal, secondLocal} {
+		for _, expected_sym := range expected {
+			result, ok := table.Resolve(expected_sym.Name)
+			if !ok {
+				t.Errorf("name %s not resolvable.", expected_sym.Name)
+			}
+
+			if result != expected_sym {
+				t.Errorf("expected %s to resolve to %+v, got=%+v", expected_sym.Name, expected_sym, result)
+			}
+		}
+	}
+}
+
 func runCompilerTest(t *testing.T, tests []compilerTestCase) {
 	t.Helper()
 

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -814,12 +814,14 @@ func TestBuiltins(t *testing.T) {
 			},
 		},
 		{
-			input: `fn(){len([])}'`,
+			input: `fn(){len([])}`,
 			expectedConstants: []interface{}{
-				code.Make(code.OpGetBuiltin, 0),
-				code.Make(code.OpArray, 0),
-				code.Make(code.OpCall, 1),
-				code.Make(code.OpReturnValue),
+				[]code.Instructions{
+					code.Make(code.OpGetBuiltin, 0),
+					code.Make(code.OpArray, 0),
+					code.Make(code.OpCall, 1),
+					code.Make(code.OpReturnValue),
+				},
 			},
 			expectedInstructions: []code.Instructions{
 				code.Make(code.OpConstant, 0),

--- a/compiler/symbol_table.go
+++ b/compiler/symbol_table.go
@@ -33,6 +33,12 @@ func (s *SymbolTable) Define(name string) Symbol {
 	return symbol
 }
 
+func (s *SymbolTable) DefineBuiltin(index int, name string) Symbol {
+	symbol := Symbol{Name: name, Index: index, Scope: BuiltinScope}
+	s.store[name] = symbol // This would be overwritten when same named global/local bindings are made.
+	return symbol
+}
+
 func (s *SymbolTable) Resolve(name string) (Symbol, bool) {
 	obj, ok := s.store[name]
 	if s.Outer == nil || ok {

--- a/compiler/symbol_table.go
+++ b/compiler/symbol_table.go
@@ -3,8 +3,9 @@ package compiler
 type SymbolScope string
 
 const (
-	GlobalScope SymbolScope = "GLOBAL"
-	LocalScope  SymbolScope = "LOCAL"
+	GlobalScope  SymbolScope = "GLOBAL"
+	LocalScope   SymbolScope = "LOCAL"
+	BuiltinScope SymbolScope = "BUILTIN"
 )
 
 type Symbol struct {

--- a/evaluator/builtins.go
+++ b/evaluator/builtins.go
@@ -11,24 +11,5 @@ var builtins = map[string]*object.Builtin{
 	"first": object.GetBuiltinByName("first"),
 	"last":  object.GetBuiltinByName("last"),
 	"rest":  object.GetBuiltinByName("rest"),
-
-	"push": {
-		Fn: func(args ...object.Object) object.Object {
-			if len(args) != 2 {
-				return newError("wrong number of arguments. got=%d, want=2", len(args))
-			}
-			if args[0].Type() != object.ARRAY_OBJ {
-				return newError("argument to `push` must be ARRAY, got=%s", args[0].Type())
-			}
-
-			arr := args[0].(*object.Array)
-			length := len(arr.Elements)
-
-			newElements := make([]object.Object, length+1, length+1)
-			copy(newElements, arr.Elements)
-			newElements[length] = args[1]
-
-			return &object.Array{Elements: newElements}
-		},
-	},
+	"push":  object.GetBuiltinByName("push"),
 }

--- a/evaluator/builtins.go
+++ b/evaluator/builtins.go
@@ -10,24 +10,7 @@ var builtins = map[string]*object.Builtin{
 	"puts":  object.GetBuiltinByName("puts"),
 	"first": object.GetBuiltinByName("first"),
 	"last":  object.GetBuiltinByName("last"),
-
-	"rest": {
-		Fn: func(args ...object.Object) object.Object {
-			if len(args) != 1 {
-				return newError("wrong number of arguments, got=%d, want=1", len(args))
-			}
-			if args[0].Type() != object.ARRAY_OBJ {
-				return newError("argument to `rest` must be ARRAY, got: %s", args[0].Type())
-			}
-			arr := args[0].(*object.Array)
-			length := len(arr.Elements)
-			if 0 < length {
-				newElements := make([]object.Object, length-1)
-				copy(newElements, arr.Elements[1:length])
-			}
-			return NULL
-		},
-	},
+	"rest":  object.GetBuiltinByName("rest"),
 
 	"push": {
 		Fn: func(args ...object.Object) object.Object {

--- a/evaluator/builtins.go
+++ b/evaluator/builtins.go
@@ -1,13 +1,13 @@
 package evaluator
 
 import (
-	"fmt"
 	"monkey/object"
 )
 
 // Holds builtin functions.
 var builtins = map[string]*object.Builtin{
-	"len": object.GetBuiltinByName("len"),
+	"len":  object.GetBuiltinByName("len"),
+	"puts": object.GetBuiltinByName("puts"),
 
 	"first": {
 		Fn: func(args ...object.Object) object.Object {
@@ -80,15 +80,6 @@ var builtins = map[string]*object.Builtin{
 			newElements[length] = args[1]
 
 			return &object.Array{Elements: newElements}
-		},
-	},
-
-	"puts": {
-		Fn: func(args ...object.Object) object.Object {
-			for _, arg := range args {
-				fmt.Println(arg.Inspect())
-			}
-			return NULL
 		},
 	},
 }

--- a/evaluator/builtins.go
+++ b/evaluator/builtins.go
@@ -9,24 +9,7 @@ var builtins = map[string]*object.Builtin{
 	"len":   object.GetBuiltinByName("len"),
 	"puts":  object.GetBuiltinByName("puts"),
 	"first": object.GetBuiltinByName("first"),
-
-	"last": {
-		Fn: func(args ...object.Object) object.Object {
-			if len(args) != 1 {
-				return newError("wrong number of arguments. got=%d, want=1", len(args))
-			}
-			if args[0].Type() != object.ARRAY_OBJ {
-				return newError("argument to `last` must be ARRAY, got: %s", args[0].Type())
-			}
-
-			arr := args[0].(*object.Array)
-			length := len(arr.Elements)
-			if 1 <= length {
-				return arr.Elements[length-1]
-			}
-			return NULL
-		},
-	},
+	"last":  object.GetBuiltinByName("last"),
 
 	"rest": {
 		Fn: func(args ...object.Object) object.Object {

--- a/evaluator/builtins.go
+++ b/evaluator/builtins.go
@@ -6,26 +6,9 @@ import (
 
 // Holds builtin functions.
 var builtins = map[string]*object.Builtin{
-	"len":  object.GetBuiltinByName("len"),
-	"puts": object.GetBuiltinByName("puts"),
-
-	"first": {
-		Fn: func(args ...object.Object) object.Object {
-			if len(args) != 1 {
-				return newError("wrong number of arguments. got=%d, want=1", len(args))
-			}
-			if args[0].Type() != object.ARRAY_OBJ {
-				return newError("argument to `first` must be ARRAY, got: %s", args[0].Type())
-			}
-
-			arr := args[0].(*object.Array)
-			length := len(arr.Elements)
-			if 1 <= length {
-				return arr.Elements[0]
-			}
-			return NULL
-		},
-	},
+	"len":   object.GetBuiltinByName("len"),
+	"puts":  object.GetBuiltinByName("puts"),
+	"first": object.GetBuiltinByName("first"),
 
 	"last": {
 		Fn: func(args ...object.Object) object.Object {

--- a/evaluator/builtins.go
+++ b/evaluator/builtins.go
@@ -7,22 +7,7 @@ import (
 
 // Holds builtin functions.
 var builtins = map[string]*object.Builtin{
-	"len": {
-		Fn: func(args ...object.Object) object.Object {
-			if len(args) != 1 {
-				return newError("wrong number of arguments. got=%d, want=1", len(args))
-			}
-
-			switch arg := args[0].(type) {
-			case *object.String:
-				return &object.Integer{Value: int64(len(arg.Value))}
-			case *object.Array:
-				return &object.Integer{Value: int64(len(arg.Elements))}
-			default:
-				return newError("argument to `len` not supported, got=%s", args[0].Type())
-			}
-		},
-	},
+	"len": object.GetBuiltinByName("len"),
 
 	"first": {
 		Fn: func(args ...object.Object) object.Object {

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -296,7 +296,10 @@ func applyFunction(fn object.Object, args []object.Object) object.Object {
 		evaluated := Eval(fn.Body, extendedEnv)
 		return unwrapReturnValue(evaluated)
 	case *object.Builtin:
-		return fn.Fn(args...)
+		if result := fn.Fn(args...); result != nil {
+			return result
+		}
+		return NULL
 	default:
 		return newError("not a function: %s", fn.Type())
 	}

--- a/object/builtins.go
+++ b/object/builtins.go
@@ -90,6 +90,7 @@ var Builtins = []struct {
 			if 0 < length {
 				newElements := make([]Object, length-1)
 				copy(newElements, arr.Elements[1:length])
+				return &Array{Elements: newElements}
 			}
 			return nil
 		}},

--- a/object/builtins.go
+++ b/object/builtins.go
@@ -2,6 +2,15 @@ package object
 
 import "fmt"
 
+func GetBuiltinByName(name string) *Builtin {
+	for _, def := range Builtins {
+		if name == def.Name {
+			return def.Builtin
+		}
+	}
+	return nil
+}
+
 var Builtins = []struct {
 	Name    string
 	Builtin *Builtin
@@ -18,7 +27,7 @@ var Builtins = []struct {
 			case *String:
 				return &Integer{Value: int64(len(arg.Value))}
 			default:
-				return newError("argument to `len` not supported. got=%s", args[0].Type())
+				return newError("argument to `len` not supported, got=%s", args[0].Type())
 			}
 		}},
 	},

--- a/object/builtins.go
+++ b/object/builtins.go
@@ -40,6 +40,24 @@ var Builtins = []struct {
 			return nil
 		}},
 	},
+	{
+		"first",
+		&Builtin{Fn: func(args ...Object) Object {
+			if len(args) != 1 {
+				return newError("wrong number of arguments. got=%d, want=1", len(args))
+			}
+			if args[0].Type() != ARRAY_OBJ {
+				return newError("argument to `first` must be ARRAY, got: %s", args[0].Type())
+			}
+
+			arr := args[0].(*Array)
+			length := len(arr.Elements)
+			if 1 <= length {
+				return arr.Elements[0]
+			}
+			return nil
+		}},
+	},
 }
 
 func newError(format string, a ...interface{}) *Error {

--- a/object/builtins.go
+++ b/object/builtins.go
@@ -1,0 +1,29 @@
+package object
+
+import "fmt"
+
+var Builtins = []struct {
+	Name    string
+	Builtin *Builtin
+}{
+	{
+		"len",
+		&Builtin{Fn: func(args ...Object) Object {
+			if len(args) != 1 {
+				return newError("wrong number of arguments. got=%d, want=1", len(args))
+			}
+			switch arg := args[0].(type) {
+			case *Array:
+				return &Integer{Value: int64(len(arg.Elements))}
+			case *String:
+				return &Integer{Value: int64(len(arg.Value))}
+			default:
+				return newError("argument to `len` not supported. got=%s", args[0].Type())
+			}
+		}},
+	},
+}
+
+func newError(format string, a ...interface{}) *Error {
+	return &Error{Message: fmt.Sprintf(format, a...)}
+}

--- a/object/builtins.go
+++ b/object/builtins.go
@@ -76,6 +76,24 @@ var Builtins = []struct {
 			return nil
 		}},
 	},
+	{
+		"rest",
+		&Builtin{Fn: func(args ...Object) Object {
+			if len(args) != 1 {
+				return newError("wrong number of arguments, got=%d, want=1", len(args))
+			}
+			if args[0].Type() != ARRAY_OBJ {
+				return newError("argument to `rest` must be ARRAY, got: %s", args[0].Type())
+			}
+			arr := args[0].(*Array)
+			length := len(arr.Elements)
+			if 0 < length {
+				newElements := make([]Object, length-1)
+				copy(newElements, arr.Elements[1:length])
+			}
+			return nil
+		}},
+	},
 }
 
 func newError(format string, a ...interface{}) *Error {

--- a/object/builtins.go
+++ b/object/builtins.go
@@ -31,6 +31,15 @@ var Builtins = []struct {
 			}
 		}},
 	},
+	{
+		"puts",
+		&Builtin{Fn: func(args ...Object) Object {
+			for _, arg := range args {
+				fmt.Println(arg.Inspect())
+			}
+			return nil
+		}},
+	},
 }
 
 func newError(format string, a ...interface{}) *Error {

--- a/object/builtins.go
+++ b/object/builtins.go
@@ -58,6 +58,24 @@ var Builtins = []struct {
 			return nil
 		}},
 	},
+	{
+		"last",
+		&Builtin{Fn: func(args ...Object) Object {
+			if len(args) != 1 {
+				return newError("wrong number of arguments. got=%d, want=1", len(args))
+			}
+			if args[0].Type() != ARRAY_OBJ {
+				return newError("argument to `last` must be ARRAY, got: %s", args[0].Type())
+			}
+
+			arr := args[0].(*Array)
+			length := len(arr.Elements)
+			if 1 <= length {
+				return arr.Elements[length-1]
+			}
+			return nil
+		}},
+	},
 }
 
 func newError(format string, a ...interface{}) *Error {

--- a/object/builtins.go
+++ b/object/builtins.go
@@ -94,6 +94,26 @@ var Builtins = []struct {
 			return nil
 		}},
 	},
+	{
+		"push",
+		&Builtin{Fn: func(args ...Object) Object {
+			if len(args) != 2 {
+				return newError("wrong number of arguments. got=%d, want=2", len(args))
+			}
+			if args[0].Type() != ARRAY_OBJ {
+				return newError("argument to `push` must be ARRAY, got=%s", args[0].Type())
+			}
+
+			arr := args[0].(*Array)
+			length := len(arr.Elements)
+
+			newElements := make([]Object, length+1)
+			copy(newElements, arr.Elements)
+			newElements[length] = args[1]
+
+			return &Array{Elements: newElements}
+		}},
+	},
 }
 
 func newError(format string, a ...interface{}) *Error {

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -31,6 +31,9 @@ func Start(in io.Reader, out io.Writer) {
 	constants := []object.Object{}
 	globals := make([]object.Object, vm.GlobalsSize)
 	symbolTable := compiler.NewSymbolTable()
+	for i, v := range object.Builtins {
+		symbolTable.DefineBuiltin(i, v.Name)
+	}
 
 	for {
 		fmt.Fprintf(out, PROMPT)

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -456,6 +456,8 @@ func (vm *VM) executeCall(numArgs int) error {
 	switch callee := callee.(type) {
 	case *object.CompiledFunction:
 		return vm.callFunction(callee, numArgs)
+	case *object.Builtin:
+		return vm.callBuiltin(callee, numArgs)
 	default:
 		return fmt.Errorf("calling non-function")
 	}
@@ -469,6 +471,19 @@ func (vm *VM) callFunction(fn *object.CompiledFunction, numArgs int) error {
 	frame := NewFrame(fn, vm.sp-numArgs)
 	vm.pushFrame(frame)
 	vm.sp = frame.basePointer + fn.NumLocals
+	return nil
+}
+
+func (vm *VM) callBuiltin(builtin *object.Builtin, numArgs int) error {
+	args := vm.stack[vm.sp-numArgs : vm.sp]
+	result := builtin.Fn(args...)
+	vm.sp = vm.sp - numArgs - 1
+
+	if result != nil {
+		vm.push(result)
+	} else {
+		vm.push(Null)
+	}
 	return nil
 }
 

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -189,7 +189,7 @@ func (vm *VM) Run() error {
 			numArgs := code.ReadUint8(ins[ip+1:])
 			vm.currentFrame().ip += 1
 
-			err := vm.callFunction(int(numArgs))
+			err := vm.executeCall(int(numArgs))
 			if err != nil {
 				return err
 			}
@@ -205,6 +205,16 @@ func (vm *VM) Run() error {
 			frame := vm.popFrame()
 			vm.sp = frame.basePointer - 1
 			err := vm.push(Null)
+			if err != nil {
+				return err
+			}
+		case code.OpGetBuiltin:
+			builtinIndex := code.ReadUint8(ins[ip+1:])
+			vm.currentFrame().ip += 1
+
+			definition := object.Builtins[builtinIndex]
+
+			err := vm.push(definition.Builtin)
 			if err != nil {
 				return err
 			}
@@ -441,12 +451,17 @@ func (vm *VM) executeHashIndex(hash, key object.Object) error {
 	return vm.push(pair.Value)
 }
 
-func (vm *VM) callFunction(numArgs int) error {
-	fn, ok := vm.stack[vm.sp-1-numArgs].(*object.CompiledFunction)
-	if !ok {
+func (vm *VM) executeCall(numArgs int) error {
+	callee := vm.stack[vm.sp-1-numArgs]
+	switch callee := callee.(type) {
+	case *object.CompiledFunction:
+		return vm.callFunction(callee, numArgs)
+	default:
 		return fmt.Errorf("calling non-function")
 	}
+}
 
+func (vm *VM) callFunction(fn *object.CompiledFunction, numArgs int) error {
 	if fn.NumParameters != numArgs {
 		return fmt.Errorf("wrong number of arguments: want=%d, got=%d", fn.NumParameters, numArgs)
 	}

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -361,7 +361,7 @@ func TestBuiltinFunctions(t *testing.T) {
 		{`len("hello world")`, 11},
 		{
 			`len(1)`,
-			&object.Error{Message: "argument to `len` not supported. got INTEGER"},
+			&object.Error{Message: "argument to `len` not supported, got=INTEGER"},
 		},
 		{`len([1,2,3])`, 3},
 		{`len([])`, 0},
@@ -370,17 +370,17 @@ func TestBuiltinFunctions(t *testing.T) {
 		// first
 		{`first([1,2,3])`, 1},
 		{`first([])`, Null},
-		{`first(1)`, &object.Error{Message: "argument to `first` must be ARRAY, got INTEGER"}},
+		{`first(1)`, &object.Error{Message: "argument to `first` must be ARRAY, got: INTEGER"}},
 		// last
 		{`last([1,2,3])`, 3},
 		{`last([])`, Null},
-		{`last(1)`, &object.Error{Message: "argument to `last` must be ARRAY, got INTEGER"}},
+		{`last(1)`, &object.Error{Message: "argument to `last` must be ARRAY, got: INTEGER"}},
 		// rest
-		{`rest([1,2,3])`, []int{2, 3}},
+		{`rest([1,2,3])`, []int{2, 3}}, // これ
 		{`rest([])`, Null},
 		// push
 		{`push([], 1)`, []int{1}},
-		{`push(1,1)`, &object.Error{Message: "argument to `push` must be ARRAY, got INTEGER"}},
+		{`push(1,1)`, &object.Error{Message: "argument to `push` must be ARRAY, got=INTEGER"}},
 	}
 	runVmTests(t, tests)
 }

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -353,6 +353,38 @@ func TestFirstClassFunctions(t *testing.T) {
 	runVmTests(t, tests)
 }
 
+func TestBuiltinFunctions(t *testing.T) {
+	tests := []vmTestCase{
+		// len
+		{`len("")`, 0},
+		{`len("four")`, 4},
+		{`len("hello world")`, 11},
+		{
+			`len(1)`,
+			&object.Error{Message: "argument to `len` not supported. got INTEGER"},
+		},
+		{`len([1,2,3])`, 3},
+		{`len([])`, 0},
+		// puts
+		{`puts("hello", "world!")`, Null},
+		// first
+		{`first([1,2,3])`, 1},
+		{`first([])`, Null},
+		{`first(1)`, &object.Error{Message: "argument to `first` must be ARRAY, got INTEGER"}},
+		// last
+		{`last([1,2,3])`, 3},
+		{`last([])`, Null},
+		{`last(1)`, &object.Error{Message: "argument to `last` must be ARRAY, got INTEGER"}},
+		// rest
+		{`rest([1,2,3])`, []int{2, 3}},
+		{`rest([])`, Null},
+		// push
+		{`push([], 1)`, []int{1}},
+		{`push(1,1)`, &object.Error{Message: "argument to `push` must be ARRAY, got INTEGER"}},
+	}
+	runVmTests(t, tests)
+}
+
 /*
 Tests the top element in the stack.
 */
@@ -450,6 +482,19 @@ func testExpectedObject(t *testing.T, expected interface{}, actual object.Object
 				t.Errorf("testIntegerObject failed: %s", err)
 			}
 		}
+	case *object.Error:
+		errObj, ok := actual.(*object.Error)
+		if !ok {
+			t.Errorf("object is not Error: %T (%+v)", actual, actual)
+			return
+		}
+		if errObj.Message != expected.Message {
+			t.Errorf(
+				"wrong error message. expected=%q, got=%q",
+				expected.Message, errObj.Message,
+			)
+		}
+
 	}
 }
 


### PR DESCRIPTION
## Why

To enable our compiler to compile and our VM to execute builtin functions, which are

- len()
- puts()
- first()
- last()
- rest()
- push()

## What

### `code` package

- Define a new opcode: `OpGetBuiltin`.
   - This has a 1-byte operand which is an identifier of the builtin function.

### `compiler` package

In terms of a symbol table, 
- Define `BuiltinScope` and add `SymbolTable#DefineBuiltin()`which is used to register builtin functions in a symbol table. The funtion’s indexes in `object.Builtins` slice is used as the identifier.

In terms of a compiler,
- Register builtin functions in a compiler's symbol table at the beginning of compiling.
- When encountering a binding to a builtin function, emit `OpGetBuiltin` instructions with the function's index in `object.Builtins` slice.

### `object` package

- Bring `object.Builtin`s from evaluator package since they would be used in compiler/vm/evaluator packages.

### `vm` package

- When encountering `OpGetBuiltin` followed by `OpCall`, fetch the corresponding function's object on the stack and call it. The object of the result would be put on the stack afterward. 
   - Note that a new frame would not be created for executing builtin functions.