### PR TITLE
[Compiler]Chapter9(1/3): Compile and execute closures

### DIFF
--- a/code/code.go
+++ b/code/code.go
@@ -38,6 +38,7 @@ const (
 	OpGetLocal
 	OpSetLocal
 	OpGetBuiltin
+	OpClosure
 )
 
 type Definition struct {
@@ -73,6 +74,7 @@ var definitions = map[Opcode]*Definition{
 	OpGetLocal:      {"OpGetLocal", []int{1}},
 	OpSetLocal:      {"OpSetLocal", []int{1}},
 	OpGetBuiltin:    {"OpGetBuiltin", []int{1}},
+	OpClosure:       {"OpClosure", []int{2, 1}}, // (index of its function in the constant pool, number of free variables)
 }
 
 func Lookup(op byte) (*Definition, error) {

--- a/code/code.go
+++ b/code/code.go
@@ -39,6 +39,7 @@ const (
 	OpSetLocal
 	OpGetBuiltin
 	OpClosure
+	OpGetFree
 )
 
 type Definition struct {
@@ -75,6 +76,7 @@ var definitions = map[Opcode]*Definition{
 	OpSetLocal:      {"OpSetLocal", []int{1}},
 	OpGetBuiltin:    {"OpGetBuiltin", []int{1}},
 	OpClosure:       {"OpClosure", []int{2, 1}}, // (index of its function in the constant pool, number of free variables)
+	OpGetFree:       {"OpGetFree", []int{1}},
 }
 
 func Lookup(op byte) (*Definition, error) {

--- a/code/code.go
+++ b/code/code.go
@@ -122,6 +122,8 @@ func (ins Instructions) fmtInstruction(def *Definition, operands []int) string {
 		return fmt.Sprintf(def.Name)
 	case 1:
 		return fmt.Sprintf("%s %d", def.Name, operands[0])
+	case 2:
+		return fmt.Sprintf("%s %d %d", def.Name, operands[0], operands[1])
 	}
 
 	return fmt.Sprintf("ERROR: unhandled operandCount for %s\n", def.Name)

--- a/code/code_test.go
+++ b/code/code_test.go
@@ -10,6 +10,7 @@ func TestMake(t *testing.T) {
 	}{
 		{OpConstant, []int{65534}, []byte{byte(OpConstant), 255, 254}},
 		{OpGetLocal, []int{255}, []byte{byte(OpGetLocal), 255}},
+		{OpClosure, []int{65534, 255}, []byte{byte(OpClosure), 255, 254, 255}},
 	}
 
 	for _, tt := range tests {
@@ -40,12 +41,14 @@ func TestInstructionsString(t *testing.T) {
 		Make(OpGetLocal, 1),
 		Make(OpConstant, 2),
 		Make(OpConstant, 65535),
+		Make(OpClosure, 65535, 255),
 	}
 
 	expected := `0000 OpAdd
 0001 OpGetLocal 1
 0003 OpConstant 2
 0006 OpConstant 65535
+0009 OpClosure 65535 255
 `
 
 	concatted := Instructions{} // array of byte arrays
@@ -70,6 +73,7 @@ func TestReadOperands(t *testing.T) {
 		{OpConstant, []int{65535}, 2},
 		{OpAdd, []int{}, 0},
 		{OpGetLocal, []int{255}, 1},
+		{OpClosure, []int{65535, 255}, 3},
 	}
 
 	for _, tt := range tests {

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -283,7 +283,8 @@ func (c *Compiler) Compile(node ast.Node) error {
 			NumLocals:     numLocals,
 			NumParameters: len(node.Parameters),
 		}
-		c.emit(code.OpConstant, c.addConstant(compiledFn))
+		fnIndex := c.addConstant(compiledFn)
+		c.emit(code.OpClosure, fnIndex, 0) // TODO: put the number of free variables as the second operand.
 	case *ast.ReturnStatement:
 		err := c.Compile(node.ReturnValue)
 		if err != nil {

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -862,6 +862,133 @@ func TestDefineResolveBuiltins(t *testing.T) {
 	}
 }
 
+func TestClosures(t *testing.T) {
+	tests := []compilerTestCase{
+		{
+			input: `
+			fn(a) {
+				fn(b) {
+					a + b
+				}
+			}`,
+			expectedConstants: []interface{}{
+				// fn(b){}
+				[]code.Instructions{
+					code.Make(code.OpGetFree, 0),  // Fetch free variable `a` to put it on the stack.
+					code.Make(code.OpGetLocal, 0), // Fetch local variable `b` to put it on the stack.
+					code.Make(code.OpAdd),
+					code.Make(code.OpReturnValue),
+				},
+				// fn(a){}
+				[]code.Instructions{
+					code.Make(code.OpGetLocal, 0),   // Put local variable `a` on the stack. This would be used as a free variable in the called function.
+					code.Make(code.OpClosure, 0, 1), // There is one free variable, which is `a` in this closure.
+					code.Make(code.OpReturnValue),
+				},
+			},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpClosure, 1, 0),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input: `
+			fn(a) {
+				fn(b) {
+					fn(c) {
+						a + b + c
+					}
+				}
+			}`,
+			expectedConstants: []interface{}{
+				// In fn(c){}
+				[]code.Instructions{
+					code.Make(code.OpGetFree, 0), // a
+					code.Make(code.OpGetFree, 1), // b
+					code.Make(code.OpAdd),
+					code.Make(code.OpGetLocal, 0), // c
+					code.Make(code.OpAdd),
+					code.Make(code.OpReturnValue),
+				},
+				// In fn(b){}
+				[]code.Instructions{
+					code.Make(code.OpGetFree, 0),  // Put `a` which is a free variable on the stack. This would be used as a free variable as well in the called function.
+					code.Make(code.OpGetLocal, 0), // Put `b` which is a local variable on the stack. This would be used as a free variable as well in the called function.
+					code.Make(code.OpClosure, 0, 2),
+					code.Make(code.OpReturnValue),
+				},
+				// In fn(a){}
+				[]code.Instructions{
+					code.Make(code.OpGetLocal, 0), // Put `a` which is a local variable on the stack. This would be used as a free variable as well in the called function.
+					code.Make(code.OpClosure, 1, 1),
+					code.Make(code.OpReturnValue),
+				},
+			},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpClosure, 2, 0),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input: `
+			let global = 55;
+			fn(){
+				let a = 66;
+				fn(){
+					let b = 77;
+					fn() {
+						let c = 88;
+						global + a + b + c;
+					}
+				}
+			}`,
+			expectedConstants: []interface{}{
+				55,
+				66,
+				77,
+				88,
+				// 4: In the innermost fn
+				[]code.Instructions{
+					code.Make(code.OpConstant, 3),  // 88
+					code.Make(code.OpSetLocal, 0),  // c =
+					code.Make(code.OpGetGlobal, 0), // global
+					code.Make(code.OpGetFree, 0),   // a
+					code.Make(code.OpAdd),
+					code.Make(code.OpGetFree, 1), // b
+					code.Make(code.OpAdd),
+					code.Make(code.OpGetLocal, 0), // c
+					code.Make(code.OpAdd),
+					code.Make(code.OpReturnValue),
+				},
+				// 5: In the middle fn
+				[]code.Instructions{
+					code.Make(code.OpConstant, 2), // 77
+					code.Make(code.OpSetLocal, 0), // b =
+					code.Make(code.OpGetFree, 0),  // Put `a` on the stack to be used as a free var in the inner fn
+					code.Make(code.OpGetLocal, 0), // Put `b` on the stack to be used as a free var in the inner fn
+					code.Make(code.OpClosure, 4, 2),
+					code.Make(code.OpReturnValue),
+				},
+				// 6: In the outermost fn
+				[]code.Instructions{
+					code.Make(code.OpConstant, 1), // 66
+					code.Make(code.OpSetLocal, 0), // a =
+					code.Make(code.OpGetLocal, 0), // Put `a` on the stack to be used as a free var in the inner fn
+					code.Make(code.OpClosure, 5, 1),
+					code.Make(code.OpReturnValue),
+				},
+			},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),  // 55
+				code.Make(code.OpSetGlobal, 0), // global =
+				code.Make(code.OpClosure, 6, 0),
+				code.Make(code.OpPop),
+			},
+		},
+	}
+	runCompilerTest(t, tests)
+}
+
 func runCompilerTest(t *testing.T, tests []compilerTestCase) {
 	t.Helper()
 

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -458,7 +458,7 @@ func TestFunctions(t *testing.T) {
 				},
 			},
 			expectedInstructions: []code.Instructions{
-				code.Make(code.OpConstant, 2),
+				code.Make(code.OpClosure, 2, 0),
 				code.Make(code.OpPop),
 			},
 		},
@@ -475,7 +475,7 @@ func TestFunctions(t *testing.T) {
 				},
 			},
 			expectedInstructions: []code.Instructions{
-				code.Make(code.OpConstant, 2),
+				code.Make(code.OpClosure, 2, 0),
 				code.Make(code.OpPop),
 			},
 		},
@@ -492,7 +492,7 @@ func TestFunctions(t *testing.T) {
 				},
 			},
 			expectedInstructions: []code.Instructions{
-				code.Make(code.OpConstant, 2),
+				code.Make(code.OpClosure, 2, 0),
 				code.Make(code.OpPop),
 			},
 		},
@@ -504,7 +504,7 @@ func TestFunctions(t *testing.T) {
 				},
 			},
 			expectedInstructions: []code.Instructions{
-				code.Make(code.OpConstant, 0),
+				code.Make(code.OpClosure, 0, 0),
 				code.Make(code.OpPop),
 			},
 		},
@@ -591,7 +591,7 @@ func TestFunctionCalls(t *testing.T) {
 				},
 			},
 			expectedInstructions: []code.Instructions{
-				code.Make(code.OpConstant, 1),
+				code.Make(code.OpClosure, 1, 0),
 				code.Make(code.OpCall),
 				code.Make(code.OpPop),
 			},
@@ -609,7 +609,7 @@ func TestFunctionCalls(t *testing.T) {
 				},
 			},
 			expectedInstructions: []code.Instructions{
-				code.Make(code.OpConstant, 1), // The compiled function
+				code.Make(code.OpClosure, 1, 0), // The compiled function
 				code.Make(code.OpSetGlobal, 0),
 				code.Make(code.OpGetGlobal, 0),
 				code.Make(code.OpCall),
@@ -629,7 +629,7 @@ func TestFunctionCalls(t *testing.T) {
 				24,
 			},
 			expectedInstructions: []code.Instructions{
-				code.Make(code.OpConstant, 0),
+				code.Make(code.OpClosure, 0, 0),
 				code.Make(code.OpSetGlobal, 0),
 				code.Make(code.OpGetGlobal, 0),
 				code.Make(code.OpConstant, 1),
@@ -652,7 +652,7 @@ func TestFunctionCalls(t *testing.T) {
 				26,
 			},
 			expectedInstructions: []code.Instructions{
-				code.Make(code.OpConstant, 0),
+				code.Make(code.OpClosure, 0, 0),
 				code.Make(code.OpSetGlobal, 0),
 				code.Make(code.OpGetGlobal, 0),
 				code.Make(code.OpConstant, 1),
@@ -676,7 +676,7 @@ func TestFunctionCalls(t *testing.T) {
 				24,
 			},
 			expectedInstructions: []code.Instructions{
-				code.Make(code.OpConstant, 0),
+				code.Make(code.OpClosure, 0, 0),
 				code.Make(code.OpSetGlobal, 0),
 				code.Make(code.OpGetGlobal, 0),
 				code.Make(code.OpConstant, 1),
@@ -704,7 +704,7 @@ func TestFunctionCalls(t *testing.T) {
 				26,
 			},
 			expectedInstructions: []code.Instructions{
-				code.Make(code.OpConstant, 0),
+				code.Make(code.OpClosure, 0, 0),
 				code.Make(code.OpSetGlobal, 0),
 				code.Make(code.OpGetGlobal, 0),
 				code.Make(code.OpConstant, 1),
@@ -735,7 +735,7 @@ func TestLetStatementScopes(t *testing.T) {
 			expectedInstructions: []code.Instructions{
 				code.Make(code.OpConstant, 0),
 				code.Make(code.OpSetGlobal, 0),
-				code.Make(code.OpConstant, 1),
+				code.Make(code.OpClosure, 1, 0),
 				code.Make(code.OpPop),
 			},
 		},
@@ -756,7 +756,7 @@ func TestLetStatementScopes(t *testing.T) {
 				},
 			},
 			expectedInstructions: []code.Instructions{
-				code.Make(code.OpConstant, 1), // fn
+				code.Make(code.OpClosure, 1, 0), // fn
 				code.Make(code.OpPop),
 			},
 		},
@@ -783,7 +783,7 @@ func TestLetStatementScopes(t *testing.T) {
 				},
 			},
 			expectedInstructions: []code.Instructions{
-				code.Make(code.OpConstant, 2), // fn
+				code.Make(code.OpClosure, 2, 0), // fn
 				code.Make(code.OpPop),
 			},
 		},
@@ -824,7 +824,7 @@ func TestBuiltins(t *testing.T) {
 				},
 			},
 			expectedInstructions: []code.Instructions{
-				code.Make(code.OpConstant, 0),
+				code.Make(code.OpClosure, 0),
 				code.Make(code.OpPop),
 			},
 		},

--- a/compiler/symbol_table.go
+++ b/compiler/symbol_table.go
@@ -19,6 +19,7 @@ type SymbolTable struct {
 	Outer          *SymbolTable
 	store          map[string]Symbol
 	numDefinitions int
+	FreeSymbols    []Symbol // Note that Scopes of all the symbols are LocalScope.
 }
 
 func (s *SymbolTable) Define(name string) Symbol {

--- a/compiler/symbol_table.go
+++ b/compiler/symbol_table.go
@@ -41,6 +41,19 @@ func (s *SymbolTable) DefineBuiltin(index int, name string) Symbol {
 	return symbol
 }
 
+/*
+Append a given Scope to the current symbol table's `FreeSymbols` slice.
+Also, define a corresponding LocalScope and register it in the current globals store.
+This newly added scope would be returned.
+*/
+func (s *SymbolTable) DefineFree(original Symbol) Symbol {
+	s.FreeSymbols = append(s.FreeSymbols, original)
+
+	symbol := Symbol{Name: original.Name, Index: len(s.FreeSymbols) - 1, Scope: FreeScope}
+	s.store[original.Name] = symbol
+	return symbol
+}
+
 func (s *SymbolTable) Resolve(name string) (Symbol, bool) {
 	obj, ok := s.store[name]
 	if s.Outer == nil || ok {

--- a/compiler/symbol_table.go
+++ b/compiler/symbol_table.go
@@ -6,6 +6,7 @@ const (
 	GlobalScope  SymbolScope = "GLOBAL"
 	LocalScope   SymbolScope = "LOCAL"
 	BuiltinScope SymbolScope = "BUILTIN"
+	FreeScope    SymbolScope = "FREE"
 )
 
 type Symbol struct {

--- a/compiler/symbol_table_test.go
+++ b/compiler/symbol_table_test.go
@@ -193,8 +193,8 @@ func TestResolveFree(t *testing.T) {
 				Symbol{Name: "f", Scope: LocalScope, Index: 1},
 			},
 			[]Symbol{
-				Symbol{Name: "c", Scope: FreeScope, Index: 0},
-				Symbol{Name: "d", Scope: FreeScope, Index: 1},
+				Symbol{Name: "c", Scope: LocalScope, Index: 0},
+				Symbol{Name: "d", Scope: LocalScope, Index: 1},
 			},
 		},
 	}

--- a/compiler/symbol_table_test.go
+++ b/compiler/symbol_table_test.go
@@ -151,3 +151,75 @@ func TestResolveNestedLocal(t *testing.T) {
 		}
 	}
 }
+
+func TestResolveFree(t *testing.T) {
+	global := NewSymbolTable()
+	global.Define("a")
+	global.Define("b")
+
+	firstLocal := NewEnclosedSymbolTable(global)
+	firstLocal.Define("c")
+	firstLocal.Define("d")
+
+	secondLocal := NewEnclosedSymbolTable(firstLocal)
+	secondLocal.Define("e")
+	secondLocal.Define("f")
+
+	tests := []struct {
+		table           *SymbolTable
+		expectedSymbols []Symbol
+		// Symbols which should be added to `FreeSymbols` slice.
+		// This should be done in the middle of the iteration below.
+		expectedFreeSymbols []Symbol
+	}{
+		{
+			firstLocal,
+			[]Symbol{
+				Symbol{Name: "a", Scope: GlobalScope, Index: 0},
+				Symbol{Name: "b", Scope: GlobalScope, Index: 1},
+				Symbol{Name: "c", Scope: LocalScope, Index: 0},
+				Symbol{Name: "d", Scope: LocalScope, Index: 1},
+			},
+			[]Symbol{},
+		},
+		{
+			secondLocal,
+			[]Symbol{
+				Symbol{Name: "a", Scope: GlobalScope, Index: 0},
+				Symbol{Name: "b", Scope: GlobalScope, Index: 1},
+				Symbol{Name: "c", Scope: FreeScope, Index: 0},
+				Symbol{Name: "d", Scope: FreeScope, Index: 1},
+				Symbol{Name: "e", Scope: LocalScope, Index: 0},
+				Symbol{Name: "f", Scope: LocalScope, Index: 1},
+			},
+			[]Symbol{
+				Symbol{Name: "c", Scope: FreeScope, Index: 0},
+				Symbol{Name: "d", Scope: FreeScope, Index: 1},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		// test elements in a symbol table
+		for _, sym := range tt.expectedSymbols {
+			result, ok := tt.table.Resolve(sym.Name)
+			if !ok {
+				t.Errorf("name %s not resolvable", sym.Name)
+			}
+			if result != sym {
+				t.Errorf("expected %s to resolve to %+v, got=%+v", sym.Name, sym, result)
+			}
+		}
+
+		// test elements in a FreeSymbols slice
+		if len(tt.table.FreeSymbols) != len(tt.expectedFreeSymbols) {
+			t.Errorf("wrong number of free symbols. got=%d, want=%d", len(tt.table.FreeSymbols), len(tt.expectedFreeSymbols))
+			continue
+		}
+		for i, sym := range tt.expectedFreeSymbols {
+			if result := tt.table.FreeSymbols[i]; result != sym {
+				t.Errorf("wrong free symbol. got=%+v,  want=%+v", result, sym)
+			}
+		}
+	}
+}

--- a/object/object.go
+++ b/object/object.go
@@ -23,6 +23,7 @@ const (
 	ARRAY_OBJ             = "ARRAY"
 	HASH_OBJ              = "HASH"
 	COMPILED_FUNCTION_OBJ = "COMPILED_FUNCTION_OBJ"
+	CLOSURE_OBJECT        = "CLOSURE_OBJECT"
 )
 
 type Object interface {
@@ -175,6 +176,14 @@ type CompiledFunction struct {
 
 func (cf *CompiledFunction) Type() ObjectType { return COMPILED_FUNCTION_OBJ }
 func (cf *CompiledFunction) Inspect() string  { return fmt.Sprintf("CompiledFunction[%p]", cf) }
+
+type Closure struct {
+	Fn   *CompiledFunction
+	Free []Object
+}
+
+func (c *Closure) Type() ObjectType { return CLOSURE_OBJECT }
+func (c *Closure) Inspect() string  { return fmt.Sprintf("Closure[%p]", c) }
 
 type Error struct {
 	Message string

--- a/vm/frame.go
+++ b/vm/frame.go
@@ -6,19 +6,19 @@ import (
 )
 
 type Frame struct {
-	fn          *object.CompiledFunction
+	cl          *object.Closure
 	ip          int
 	basePointer int
 }
 
-func NewFrame(fn *object.CompiledFunction, basePointer int) *Frame {
+func NewFrame(closure *object.Closure, basePointer int) *Frame {
 	return &Frame{
-		fn: fn,
-		ip: -1,
+		cl:          closure,
+		ip:          -1,
 		basePointer: basePointer,
 	}
 }
 
 func (f *Frame) Instructions() code.Instructions {
-	return f.fn.Instructions
+	return f.cl.Fn.Instructions
 }

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -156,6 +156,15 @@ func (vm *VM) Run() error {
 			if err != nil {
 				return err
 			}
+		case code.OpGetFree:
+			freeIndex := code.ReadUint8(ins[ip+1:])
+			vm.currentFrame().ip += 1
+
+			currentClosure := vm.currentFrame().cl
+			err := vm.push(currentClosure.Free[freeIndex])
+			if err != nil {
+				return err
+			}
 		case code.OpArray:
 			numElements := int(code.ReadUint16(ins[ip+1:]))
 			vm.currentFrame().ip += 2
@@ -221,10 +230,10 @@ func (vm *VM) Run() error {
 			}
 		case code.OpClosure:
 			constIndex := code.ReadUint16(ins[ip+1:])
-			code.ReadUint8(ins[ip+3:]) // TODO: Handle the second operand which stands for the number of free variables
+			numFree := code.ReadUint8(ins[ip+3:])
 			vm.currentFrame().ip += 3
 
-			err := vm.pushClosure(int(constIndex))
+			err := vm.pushClosure(int(constIndex), int(numFree))
 			if err != nil {
 				return err
 			}
@@ -497,14 +506,23 @@ func (vm *VM) callBuiltin(builtin *object.Builtin, numArgs int) error {
 	return nil
 }
 
-func (vm *VM) pushClosure(constIndex int) error {
+func (vm *VM) pushClosure(constIndex int, numFree int) error {
 	constant := vm.constants[constIndex]
 	function, ok := constant.(*object.CompiledFunction)
 	if !ok {
 		return fmt.Errorf("not a function: %+v", constant)
 	}
 
-	closure := &object.Closure{Fn: function}
+	free := make([]object.Object, numFree)
+	for i := 0; i < numFree; i++ {
+		free[i] = vm.stack[vm.sp-numFree+i]
+	}
+	vm.sp = vm.sp - numFree
+
+	closure := &object.Closure{
+		Fn:   function,
+		Free: free,
+	}
 	return vm.push(closure)
 }
 

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -385,6 +385,19 @@ func TestBuiltinFunctions(t *testing.T) {
 	runVmTests(t, tests)
 }
 
+func TestClosures(t *testing.T) {
+	tests := []vmTestCase{
+		{
+			input: `
+			let newClosure = fn(a){ fn(){a;}; }
+			let closure = newClosure(99)
+			closure()`,
+			expected: 99,
+		},
+	}
+	runVmTests(t, tests)
+}
+
 /*
 Tests the top element in the stack.
 */

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -394,6 +394,23 @@ func TestClosures(t *testing.T) {
 			closure()`,
 			expected: 99,
 		},
+		{
+			input: `
+			let newAddr = fn(a, b){ fn(c){ return a+b+c }; }
+			let adder = newAddr(1, 2)
+			adder(8)`,
+			expected: 11,
+		},
+		{
+			input: `
+			let newAdder = fn(a, b){
+				let c = a + b;
+				fn(d) { c + d };
+			}
+			let adder = newAdder(1, 2)
+			adder(8)`,
+			expected: 11,
+		},
 	}
 	runVmTests(t, tests)
 }


### PR DESCRIPTION
## Why

To compile and execute closures.

```js
let newClosure = fn(a){ fn(){a;}; }
let closure = newClosure(99)
closure()
```



## What

statistics: 
Encompass all the CompiledFunction objects in Closure objects.
Now, Frame holds a corresponding closure, 

### `code` package

Add new opcodes:
- `OpClosure` whose operands stand for `(index of its function in the constant pool, number of free variables)` 
- `OpGetFree` whose operand stands for `index of a free variable`

### `compiler` package

When compiling a `FunctionLiteral`, 


### `object` package

Define `Closure` object which holds
- `CompiledFunction`
- `Free` which is a slice of objects (corresponding to free variables).


### `vm` package

