### PR TITLE
[Compiler]Chapter9(2/3): Compile and execute closures which are defined in the LOCAL scope

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -200,11 +200,11 @@ func (c *Compiler) Compile(node ast.Node) error {
 			}
 		}
 	case *ast.LetStatement:
+		symbol := c.symbolTable.Define(node.Name.Value)
 		err := c.Compile(node.Value)
 		if err != nil {
 			return err
 		}
-		symbol := c.symbolTable.Define(node.Name.Value)
 		if symbol.Scope == GlobalScope {
 			c.emit(code.OpSetGlobal, symbol.Index)
 		} else {

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -415,6 +415,24 @@ func TestClosures(t *testing.T) {
 	runVmTests(t, tests)
 }
 
+func TestRecursiveFunctions(t *testing.T) {
+	tests := []vmTestCase{
+		{
+			input: `
+			let countDown = fn(x) {
+				if (x == 0) {
+					return 0;
+				} else {
+					countDown(x-1)
+				}
+			};
+			countDown(1);`,
+			expected: 0,
+		},
+	}
+	runVmTests(t, tests)
+}
+
 /*
 Tests the top element in the stack.
 */

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -429,6 +429,21 @@ func TestRecursiveFunctions(t *testing.T) {
 			countDown(1);`,
 			expected: 0,
 		},
+		{
+			input: `
+			let countDown = fn(x) {
+				if (x == 0) {
+					return 0;
+				} else {
+					countDown(x-1)
+				}
+			};
+			let wrapper = fn() {
+				countDown(1)
+			}
+			wrapper();`,
+			expected: 0,
+		},
 	}
 	runVmTests(t, tests)
 }


### PR DESCRIPTION
## Why

To compile a recursive closures which are defined in the GLOBAL scope
e.g.

```js
let countDown = fn(x) {
    if (x == 0) {
        return 0;
    } else {
	countDown(x-1)
    }
};
countDown(1);
```



## What

When compiling LetStatement node, register the global recursive function in the symbol table before compiling the body.