### PR TITLE
[Compiler]Chapter9(3/3): Fix to compile and execute closures which are defined in the GLOBAL scope

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -2,6 +2,7 @@ package ast
 
 import (
 	"bytes"
+	"fmt"
 	"monkey/token"
 	"strings"
 )
@@ -231,6 +232,9 @@ func (fl *FunctionLiteral) String() string {
 		params = append(params, p.String())
 	}
 	out.WriteString(fl.TokenLiteral())
+	if fl.Name != "" {
+		out.WriteString(fmt.Sprintf("<%s>", fl.Name))
+	}
 	out.WriteString("(")
 	out.WriteString(strings.Join(params, ", "))
 	out.WriteString(") ")

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -218,6 +218,7 @@ type FunctionLiteral struct {
 	Token      token.Token //= 'fn'
 	Parameters []*Identifier
 	Body       *BlockStatement
+	Name       string
 }
 
 func (fl *FunctionLiteral) expressionNode()      {}

--- a/code/code.go
+++ b/code/code.go
@@ -40,6 +40,7 @@ const (
 	OpGetBuiltin
 	OpClosure
 	OpGetFree
+	OpCurrentClosure // Used when calling the function itself recursively in a function in a local (not global) context.
 )
 
 type Definition struct {
@@ -48,35 +49,36 @@ type Definition struct {
 }
 
 var definitions = map[Opcode]*Definition{
-	OpConstant:      {"OpConstant", []int{2}}, // Thus, up to 65536 constants could be defied.
-	OpTrue:          {"OpTrue", []int{}},
-	OpFalse:         {"OpFalse", []int{}},
-	OpAdd:           {"OpAdd", []int{}},
-	OpSub:           {"OpSub", []int{}},
-	OpMul:           {"OpMul", []int{}},
-	OpDiv:           {"OpDiv", []int{}},
-	OpEqual:         {"OpEqual", []int{}},
-	OpNotEqual:      {"OpNotEqual", []int{}},
-	OpGreaterThan:   {"OpGreaterThan", []int{}},
-	OpMinus:         {"OpMinus", []int{}},
-	OpBang:          {"OpBang", []int{}},
-	OpPop:           {"OpPop", []int{}},
-	OpJumpNotTruthy: {"OpJumpNotTruthy", []int{2}},
-	OpJump:          {"OpJump", []int{2}},
-	OpNull:          {"OpNull", []int{}},
-	OpGetGlobal:     {"OpGetGlobal", []int{2}},
-	OpSetGlobal:     {"OpSetGlobal", []int{2}},
-	OpArray:         {"OpArray", []int{2}},
-	OpHash:          {"OpHash", []int{2}},
-	OpIndex:         {"OpIndex", []int{}},
-	OpCall:          {"OpCall", []int{1}}, // An operand stands for number of arguments.
-	OpReturnValue:   {"OpReturnValue", []int{}},
-	OpReturn:        {"OpReturn", []int{}},
-	OpGetLocal:      {"OpGetLocal", []int{1}},
-	OpSetLocal:      {"OpSetLocal", []int{1}},
-	OpGetBuiltin:    {"OpGetBuiltin", []int{1}},
-	OpClosure:       {"OpClosure", []int{2, 1}}, // (index of its function in the constant pool, number of free variables)
-	OpGetFree:       {"OpGetFree", []int{1}},
+	OpConstant:       {"OpConstant", []int{2}}, // Thus, up to 65536 constants could be defied.
+	OpTrue:           {"OpTrue", []int{}},
+	OpFalse:          {"OpFalse", []int{}},
+	OpAdd:            {"OpAdd", []int{}},
+	OpSub:            {"OpSub", []int{}},
+	OpMul:            {"OpMul", []int{}},
+	OpDiv:            {"OpDiv", []int{}},
+	OpEqual:          {"OpEqual", []int{}},
+	OpNotEqual:       {"OpNotEqual", []int{}},
+	OpGreaterThan:    {"OpGreaterThan", []int{}},
+	OpMinus:          {"OpMinus", []int{}},
+	OpBang:           {"OpBang", []int{}},
+	OpPop:            {"OpPop", []int{}},
+	OpJumpNotTruthy:  {"OpJumpNotTruthy", []int{2}},
+	OpJump:           {"OpJump", []int{2}},
+	OpNull:           {"OpNull", []int{}},
+	OpGetGlobal:      {"OpGetGlobal", []int{2}},
+	OpSetGlobal:      {"OpSetGlobal", []int{2}},
+	OpArray:          {"OpArray", []int{2}},
+	OpHash:           {"OpHash", []int{2}},
+	OpIndex:          {"OpIndex", []int{}},
+	OpCall:           {"OpCall", []int{1}}, // An operand stands for number of arguments.
+	OpReturnValue:    {"OpReturnValue", []int{}},
+	OpReturn:         {"OpReturn", []int{}},
+	OpGetLocal:       {"OpGetLocal", []int{1}},
+	OpSetLocal:       {"OpSetLocal", []int{1}},
+	OpGetBuiltin:     {"OpGetBuiltin", []int{1}},
+	OpClosure:        {"OpClosure", []int{2, 1}}, // (index of its function in the constant pool, number of free variables)
+	OpGetFree:        {"OpGetFree", []int{1}},
+	OpCurrentClosure: {"OpCurrentClosure", []int{}},
 }
 
 func Lookup(op byte) (*Definition, error) {

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -257,6 +257,12 @@ func (c *Compiler) Compile(node ast.Node) error {
 		c.emit(code.OpIndex)
 	case *ast.FunctionLiteral:
 		c.enterScope()
+
+		// Register a name of the called function in the FunctionScope of the symbolTable.
+		if node.Name != "" {
+			c.symbolTable.DefineFunctionName(node.Name)
+		}
+
 		for _, p := range node.Parameters {
 			// Arguments are already put on the bottom of the stack by the caller before calling this function.
 			// So we just have to reserve the indexes here.
@@ -405,6 +411,8 @@ func (c *Compiler) loadSymbol(symbol Symbol) {
 		c.emit(code.OpGetBuiltin, symbol.Index)
 	case FreeScope:
 		c.emit(code.OpGetFree, symbol.Index)
+	case FunctionScope:
+		c.emit(code.OpCurrentClosure)
 	}
 }
 

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -1045,7 +1045,7 @@ func TestClosures(t *testing.T) {
 			expectedInstructions: []code.Instructions{
 				code.Make(code.OpClosure, 3, 0),
 				code.Make(code.OpSetGlobal, 0), // wrapper =
-				code.Make(code.OpGetGlobal, 1),
+				code.Make(code.OpGetGlobal, 0),
 				code.Make(code.OpCall, 0),
 				code.Make(code.OpPop),
 			},

--- a/compiler/symbol_table.go
+++ b/compiler/symbol_table.go
@@ -3,10 +3,11 @@ package compiler
 type SymbolScope string
 
 const (
-	GlobalScope  SymbolScope = "GLOBAL"
-	LocalScope   SymbolScope = "LOCAL"
-	BuiltinScope SymbolScope = "BUILTIN"
-	FreeScope    SymbolScope = "FREE"
+	GlobalScope   SymbolScope = "GLOBAL"
+	LocalScope    SymbolScope = "LOCAL"
+	BuiltinScope  SymbolScope = "BUILTIN"
+	FreeScope     SymbolScope = "FREE"
+	FunctionScope SymbolScope = "FUNCTION"
 )
 
 type Symbol struct {

--- a/compiler/symbol_table.go
+++ b/compiler/symbol_table.go
@@ -55,6 +55,12 @@ func (s *SymbolTable) DefineFree(original Symbol) Symbol {
 	return symbol
 }
 
+func (s *SymbolTable) DefineFunctionName(name string) Symbol {
+	symbol := Symbol{Name: name, Index: 0, Scope: FunctionScope} // Index does not matter.
+	s.store[name] = symbol
+	return symbol
+}
+
 func (s *SymbolTable) Resolve(name string) (Symbol, bool) {
 	obj, okInLocal := s.store[name]
 	if okInLocal || s.Outer == nil {

--- a/compiler/symbol_table_test.go
+++ b/compiler/symbol_table_test.go
@@ -282,3 +282,18 @@ func TestDefineAndResolveFunctionName(t *testing.T) {
 		t.Errorf("expected %s to resolve to %+v, got=%+v", expected.Name, expected, result)
 	}
 }
+
+func TestShadowingFunctionName(t *testing.T) {
+	global := NewSymbolTable()
+	global.DefineFunctionName("a")
+	global.Define("a")
+
+	expected := Symbol{Name: "a", Scope: GlobalScope, Index: 0}
+	result, ok := global.Resolve(expected.Name)
+	if !ok {
+		t.Fatalf("function name %s not resolvable", expected.Name)
+	}
+	if result != expected {
+		t.Errorf("expected %s to resolve to %+v, got=%+v", expected.Name, expected, result)
+	}
+}

--- a/compiler/symbol_table_test.go
+++ b/compiler/symbol_table_test.go
@@ -268,3 +268,17 @@ func TestResolveUnresolvableFree(t *testing.T) {
 		}
 	}
 }
+
+func TestDefineAndResolveFunctionName(t *testing.T) {
+	global := NewSymbolTable()
+	global.DefineFunctionName("a")
+
+	expected := Symbol{Name: "a", Scope: FunctionScope, Index: 0}
+	result, ok := global.Resolve(expected.Name)
+	if !ok {
+		t.Fatalf("function name %s not resolvable", expected.Name)
+	}
+	if result != expected {
+		t.Errorf("expected %s to resolve to %+v, got=%+v", expected.Name, expected, result)
+	}
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -441,6 +441,10 @@ func (p *Parser) parseLetStatement() *ast.LetStatement {
 	if p.peekTokenIs(token.SEMICOLON) {
 		p.nextToken()
 	}
+
+	if fl, ok := stmt.Value.(*ast.FunctionLiteral); ok {
+		fl.Name = stmt.Name.Value
+	}
 	return stmt
 }
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -856,6 +856,32 @@ func TestParsingHashLiteralWithExpressions(t *testing.T) {
 	}
 }
 
+func TestFunctionLiteralWithName(t *testing.T) {
+	input := `let myFunction = fn(){};`
+	l := lexer.New(input)
+	p := New(l)
+	program := p.ParseProgram()
+	checkParserErrors(t, p)
+
+	if len(program.Statements) != 1 {
+		t.Fatalf("program.Body does not contain %d statements. got=%d", 1, len(program.Statements))
+	}
+
+	stmt, ok := program.Statements[0].(*ast.LetStatement)
+	if !ok {
+		t.Fatalf("program.Statements[0] is not ast.LetStatement. got=%T", program.Statements[0])
+	}
+
+	function, ok := stmt.Value.(*ast.FunctionLiteral)
+	if !ok {
+		t.Fatalf("stmt.Value is not ast.FunctionLiteral. got=%T", stmt.Value)
+	}
+
+	if function.Name != "myFunction" {
+		t.Fatalf("function literal name wrong. want 'myFunction', got=%q\n", function.Name)
+	}
+}
+
 func testInfixExpression(
 	t *testing.T,
 	exp ast.Expression,

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -237,6 +237,12 @@ func (vm *VM) Run() error {
 			if err != nil {
 				return err
 			}
+		case code.OpCurrentClosure:
+			currentClosure := vm.currentFrame().cl
+			err := vm.push(currentClosure)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -444,6 +444,36 @@ func TestRecursiveFunctions(t *testing.T) {
 			wrapper();`,
 			expected: 0,
 		},
+		{
+			input: `
+			let countDown = fn(x) {
+				if (x == 0) {
+					return 0;
+				} else {
+					countDown(x-1)
+				}
+			};
+			let wrapper = fn() {
+				countDown(1)
+			}
+			wrapper();`,
+			expected: 0,
+		},
+		{
+			input: `
+			let wrapper = fn() {
+				let countDown = fn(x) {
+					if (x == 0) {
+						return 0;
+					} else {
+						countDown(x-1)
+					}
+				};
+				countDown(1)
+			}
+			wrapper();`,
+			expected: 0,
+		},
 	}
 	runVmTests(t, tests)
 }
@@ -462,6 +492,18 @@ func runVmTests(t *testing.T, tests []vmTestCase) {
 			t.Fatalf("compiler error: %s", err)
 		}
 		// Assume that the logic till here (till compiling) is right.
+
+		for i, constant := range comp.ByteCode().Constants {
+			fmt.Printf("CONSTANT %d %p (%T)", i, constant, constant)
+
+			switch constant := constant.(type) {
+			case *object.CompiledFunction:
+				fmt.Printf("	Instructions: \n%s", constant.Instructions)
+			case *object.Integer:
+				fmt.Printf("	Value: %d\n", constant.Value)
+			}
+			fmt.Printf("\n")
+		}
 
 		vm := New(comp.ByteCode())
 		err = vm.Run()


### PR DESCRIPTION
## Why

To compile a recursive closures which are defined in the GLOBAL scope.

e.g.

```js
let wrapper = fn() {
    let countDown = fn(x) {
	    if (x == 0) {
		    return 0;
	    } else {
		    countDown(x-1)
	    }
    };
    countDown(1)
}
wrapper();
```


## What


### `parser` package, `ast` package

In `ast` package, 
- Hold `Name` in a `FunctionLiteral` struct. This stands for the name of the variable which this function is bound to.

In `parser` package,
- Set `Name` of `FunctionLiteral` node when parsing ast.LetStatement.

### `code` package

- Add a new Opcode `OpCurrentClosure` which takes no operand.

### `compiler package`

In symbol table,
- Add a new scope: `FunctionScope`
- Add `SymbolTable#DefineFunctionName` to register a FunctionScope symbol with a given name in a table.

### `vm` package

- When encountering `OpCurrentClosure` opcode, push an object which corresponds to the current function on the stack.