### PR TITLE
[Fix]Update `evalutor.unwrapReturnValue()`

### DIFF
--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -319,7 +319,7 @@ func extendFunctionEnv(
 
 func unwrapReturnValue(obj object.Object) object.Object {
 	if returnValue, ok := obj.(*object.ReturnValue); ok {
-		return returnValue
+		return returnValue.Value
 	}
 	return obj
 }

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -461,6 +461,34 @@ func TestHashIndexExpression(t *testing.T) {
 	}
 }
 
+func TestReturnStatementsInFunctions(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		{
+			input: `
+			let f = fn(x) {
+				return 1;
+			}
+			f(1) + f(1)`,
+			expected: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		evaluated := testEval(tt.input)
+		if errObj, ok := evaluated.(*object.Error); ok {
+			t.Errorf("Error when evaluating. Error message is: %s", errObj.Message)
+		}
+		integer, ok := tt.expected.(int)
+		if !ok {
+			t.Errorf("returned value is %T, want=integer", integer)
+		}
+		testIntegerObject(t, evaluated, int64(integer))
+	}
+}
+
 func testEval(input string) object.Object {
 	l := lexer.New(input)
 	p := parser.New(l)


### PR DESCRIPTION
## Why

When evaluating a function below,  I got an error which complains with `unknown operator: RETURN_VALUE + RETURN_VALUE`.

```ts
let f = fn(x) {
    return 1;
}
f(1) + f(1)
```

This should be fixed.

## What

Fix `evalutor.unwrapReturnValue()` to unwrap ReturnValue object correctly.
