### PR TITLE
Add benchmark to compare performance of our interpreter and our compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,39 @@ VM:
 
 - creates objects from bytecode
 - uses the constant pool built in the compiler
+
+
+## How to test
+
+```sh
+go test ./
+```
+
+## Performance of interpreter vs compiler
+
+Run the snippet below with our interpreter/ our compiler to compare their performances.
+
+```js
+let fibonacci = fn(x) {
+  if (x == 0) {
+    0
+  } else {
+    if (x == 1) {
+      return 1;
+    } else {
+      fibonacci(x-1) + fibonacci(x-2)
+    }
+  }
+}
+fibonacci(35)
+```
+
+The result reveals that our compiler runs **3 times faster** than our interpreter.
+
+```sh
+$ go run benchmark/main.go -engine=vm
+engine=vm, result=9227465, duration=11.787990726s
+
+$ go run benchmark/main.go -engine=eval
+engine=eval, result=9227465, duration=37.105657782s
+```

--- a/benchmark/main.go
+++ b/benchmark/main.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"monkey/compiler"
+	"monkey/evaluator"
+	"monkey/lexer"
+	"monkey/object"
+	"monkey/parser"
+	"monkey/vm"
+	"time"
+)
+
+var engine = flag.String("engine", "vm", "use 'vm' or 'eval'")
+
+var input = `
+	let fibonacci = fn(x) {
+		if (x == 0) {
+			0
+		} else {
+			if (x == 1) {
+				return 1;
+			} else {
+				fibonacci(x-1) + fibonacci(x-2)
+			}
+		}
+	}
+	fibonacci(35)`
+
+func main() {
+	flag.Parse()
+
+	var duration time.Duration
+	var result object.Object
+
+	l := lexer.New(input)
+	p := parser.New(l)
+	program := p.ParseProgram()
+
+	if *engine == "vm" {
+		comp := compiler.New()
+		err := comp.Compile(program)
+		if err != nil {
+			fmt.Printf("compiler error: %s", err)
+			return
+		}
+
+		machine := vm.New(comp.ByteCode())
+		start := time.Now()
+		err = machine.Run()
+		if err != nil {
+			fmt.Printf("vm error: %s", err)
+		}
+
+		result = machine.LastPoppedStackElem()
+		duration = time.Since(start)
+	} else {
+		env := object.NewEnvironment()
+		start := time.Now()
+		result = evaluator.Eval(program, env)
+		duration = time.Since(start)
+	}
+
+	fmt.Printf(
+		"engine=%s, result=%s, duration=%s\n",
+		*engine,
+		result.Inspect(),
+		duration,
+	)
+}


### PR DESCRIPTION
## Why 

To investigate how much our compiler is faster than our interpreter.

## What

Add benchmark to compare their performances.

```js
let fibonacci = fn(x) {
  if (x == 0) {
    0
  } else {
    if (x == 1) {
      return 1;
    } else {
      fibonacci(x-1) + fibonacci(x-2)
    }
  }
}
fibonacci(35)
```